### PR TITLE
Change tag naming from vX.Y.Z to vX.Y.Z+vA.B.C

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ To ensure consistent feature set across external binding generators, `uniffi-bin
 a specific `uniffi-rs` version. A consumer using Go bindings (in `uniffi-bindgen-go`) and Go
 bindings (in `uniffi-bindgen-go`) expects the same features to be available across multiple bindings
 generators. This means that the consumer should choose external binding generator versions such that
-each generator targets the same `uniffi-rs` version. The table shows `uniffi-rs` version history
-to make it easier to understand when `uniffi-rs` version has changed.
+each generator targets the same `uniffi-rs` version.
 
-| uniffi-bindgen-go version                | uniffi-rs version                                |
-|------------------------------------------|--------------------------------------------------|
-| v0.1.0                                   | v0.23.0                                          |
+To simplify this choice `uniffi-bindgen-cs` and `uniffi-bindgen-go` use tag naming convention
+as follows: `vX.Y.Z+vA.B.C`, where `X.Y.Z` is the version of the generator itself, and `A.B.C` is
+the version of uniffi-rs it is based on.


### PR DESCRIPTION
Change tag naming from vX.Y.Z to vX.Y.Z+vA.B.C to include upstream uniffi version