### PR TITLE
Two small bug fixes

### DIFF
--- a/bindgen/src/lib.rs
+++ b/bindgen/src/lib.rs
@@ -60,6 +60,7 @@ impl uniffi_bindgen::BindingGenerator for BindingGeneratorGo {
         go_file.push(format!("{}.go", ci.namespace()));
         let mut f = File::create(&go_file)?;
         write!(f, "{}", generate_go_bindings(&config, &ci)?)?;
+        drop(f);
 
         if self.try_format_code {
             match Command::new("go").arg("fmt").arg(&go_file).output() {

--- a/bindgen/templates/EnumTemplate.go
+++ b/bindgen/templates/EnumTemplate.go
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */#}
 
-{{ self.add_import("encoding/binary") -}}
 {% let e = ci.get_enum_definition(name).unwrap() -%}
 {%- if e.is_flat() -%}
 


### PR DESCRIPTION
1. Close generated binding file before formatting
Otherwise the fmt may fail if the file cache
is not saved to the disk after the write
2. Remove unnecessery import from EnumTemplate.go.
It doubles the one in wrapper.go and in case
go fmt is not used it breakes bindings compilation.