### PR TITLE
Add missing lock in callbacks

### DIFF
--- a/bindgen/templates/CallbackInterfaceRuntime.go
+++ b/bindgen/templates/CallbackInterfaceRuntime.go
@@ -11,7 +11,7 @@ type concurrentHandleMap[T any] struct {
 	leftMap       map[uint64]*T
 	rightMap      map[*T]uint64
 	currentHandle uint64
-	lock          sync.Mutex
+	lock          sync.RWMutex
 }
 
 func newConcurrentHandleMap[T any]() *concurrentHandleMap[T] {
@@ -24,6 +24,7 @@ func newConcurrentHandleMap[T any]() *concurrentHandleMap[T] {
 func (cm *concurrentHandleMap[T]) insert(obj *T) uint64 {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
+
 	if existingHandle, ok := cm.rightMap[obj]; ok {
 		return existingHandle
 	}
@@ -36,6 +37,7 @@ func (cm *concurrentHandleMap[T]) insert(obj *T) uint64 {
 func (cm *concurrentHandleMap[T]) remove(handle uint64) bool {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
+
 	if val, ok := cm.leftMap[handle]; ok {
 		delete(cm.leftMap, handle)
 		delete(cm.rightMap, val)
@@ -44,6 +46,9 @@ func (cm *concurrentHandleMap[T]) remove(handle uint64) bool {
 }
 
 func (cm *concurrentHandleMap[T]) tryGet(handle uint64) (*T, bool) {
+	cm.lock.RLock()
+	defer cm.lock.RUnlock()
+
 	val, ok := cm.leftMap[handle]
 	return val, ok
 }


### PR DESCRIPTION
Use RWMutex, because callback invocations are read heavy.

Fixes #28 