### PR TITLE
Bump v0.2.0+v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+----
+
+### v0.2.0+v0.25.0
+
+- **BREAKING**: Update to uniffi 0.25.0.
+- **IMPORTANT**: Fix race condition in callback handling code [#28](https://github.com/NordSecurity/uniffi-bindgen-go/issues/28).
+- Implement `--library-mode` command line option.
+- Implement async functions and methods.
+- implement foreign executor.
+- Implement `bytes` type.
+- Implement external types.
+- Fix incorrect code emitted for all caps acronyms in objects and callbacks, e.g. `HTTPClient`.
+
+----
+
+### v0.1.5+v0.23.0
+
+- **IMPORTANT**: Fix memory leak for all strings being read from FFI.
+
+### v0.1.4+v0.23.0
+
+- Fix typo in generated Go bindings for associated enum case with no fields.
+
+### v0.1.3+v0.23.0
+
+- Closing generated binding file before formatting.
+- Removed unnecessery import from EnumTemplate.go.
+
+### v0.1.2+v0.23.0
+
+- Fix 0.1 release to be compatible with mozilla/uniffi-rs 0.23.0 after docstring changes.
+
+### v0.1.1+v0.23.0
+
+- Changed callback return type to `C.uint64_t`.
+
+### v0.1.0+v0.23.0
+
+- Updated version tag pattern.
+
+----

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen-go"
-version = "0.1.2+v.0.25.0"
+version = "0.2.0+v0.25.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 Generate [UniFFI](https://github.com/mozilla/uniffi-rs) bindings for Go. `uniffi-bindgen-go` lives
 as a separate project from `uniffi-go`, as per
 [uniffi-rs #1355](https://github.com/mozilla/uniffi-rs/issues/1355). Currently, `uniffi-bindgen-go`
-uses `uniffi-rs` version `0.23.0`.
+uses `uniffi-rs` version `0.25.0`.
 
 # How to install
 
-Minimum Rust version required to install `uniffi-bindgen-go` is `1.64`.
+Minimum Rust version required to install `uniffi-bindgen-go` is `1.70`.
 Newer Rust versions should also work fine.
 
 ```
-cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go
+cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.0+v0.25.0
 ```
 
 # How to generate bindings
@@ -29,48 +29,11 @@ Generated bindings require Go 1.19 or later to compile.
 
 # Configuration options
 
-It's possible to configure some settings by passing `--config` argument to the generator. All
-configuration keys are defined in `bindings.go` section.
+It's possible to [configure some settings](docs/CONFIGURATION.md) by passing `--config` argument to
+the generator
 ```bash
 uniffi-bindgen-go path/to/definitions.udl --config path/to/uniffi.toml
 ```
-
-- `package_name` - override the go package name.
-
-- `custom_types` - properties for custom type defined in UDL with `[Custom] typedef string Url;`.
-    ```toml
-    # Represent URL as a native Go `url.Url`. The underlying type of URL is a string.
-    imports = ["net/url"]
-    type_name = "url.URL"
-    into_custom = """u, err := url.Parse({})
-        if err != nil {
-             panic(err)
-        }
-        return *u
-    """
-    from_custom = "{}.String()"
-    ```
-
-    - `imports` (optional) - any imports required to satisfy this type.
-
-    - `type_name` (optional) - the name to represent the type in generated bindings. Default is the
-        type alias name from UDL, e.g. `Url`.
-
-    - `into_custom` (required) - an expression to convert from the underlying type into custom type. `{}` will
-        will be expanded into variable containing the underlying value. The expression is used in a
-        return statement, i.e. `return <expression(value)>;`.
-
-    - `from_custom` (required) - an expression to convert from the custom type into underlying type. `{}` will
-        will be expanded into variable containing the custom value. The expression is used in a
-        return statement, i.e. `return <expression(value);>`.
-
-- `go_mod` (optional) - Specify the go module for the final package, used as imports source for external types.
-
-- `c_module_filename`(optional) - override the name of the `C` module (`.h` and `.c`)
-
-# Contributing
-
-For contribution guidelines, read [CONTRIBUTING.md](CONTRIBUTING.md)
 
 # Versioning
 
@@ -92,3 +55,18 @@ each generator targets the same `uniffi-rs` version.
 To simplify this choice `uniffi-bindgen-cs` and `uniffi-bindgen-go` use tag naming convention
 as follows: `vX.Y.Z+vA.B.C`, where `X.Y.Z` is the version of the generator itself, and `A.B.C` is
 the version of uniffi-rs it is based on.
+
+The table shows `uniffi-rs` version history for tags that were published before tag naming convention described above was introduced.
+
+| uniffi-bindgen-cs version                | uniffi-rs version                                |
+|------------------------------------------|--------------------------------------------------|
+| v0.2.0                                   | v0.25.0                                          |
+| v0.1.0                                   | v0.23.0                                          |
+
+# Documentation
+
+More documentation is available in [docs](docs) directory.
+
+# Contributing
+
+For contribution guidelines, read [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ the version of uniffi-rs it is based on.
 
 The table shows `uniffi-rs` version history for tags that were published before tag naming convention described above was introduced.
 
-| uniffi-bindgen-cs version                | uniffi-rs version                                |
+| uniffi-bindgen-go version                | uniffi-rs version                                |
 |------------------------------------------|--------------------------------------------------|
 | v0.2.0                                   | v0.25.0                                          |
 | v0.1.0                                   | v0.23.0                                          |

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-go"
-version = "0.1.2+v.0.25.0"
+version = "0.2.0+v0.25.0"
 edition = "2021"
 
 [lib]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,40 @@
+# Configuration options
+
+It's possible to configure some settings by passing `--config` argument to the generator. All
+configuration keys are defined in `bindings.go` section.
+```bash
+uniffi-bindgen-go path/to/definitions.udl --config path/to/uniffi.toml
+```
+
+- `package_name` - override the go package name.
+
+- `custom_types` - properties for custom type defined in UDL with `[Custom] typedef string Url;`.
+    ```toml
+    # Represent URL as a native Go `url.Url`. The underlying type of URL is a string.
+    imports = ["net/url"]
+    type_name = "url.URL"
+    into_custom = """u, err := url.Parse({})
+        if err != nil {
+             panic(err)
+        }
+        return *u
+    """
+    from_custom = "{}.String()"
+    ```
+
+    - `imports` (optional) - any imports required to satisfy this type.
+
+    - `type_name` (optional) - the name to represent the type in generated bindings. Default is the
+        type alias name from UDL, e.g. `Url`.
+
+    - `into_custom` (required) - an expression to convert from the underlying type into custom type. `{}` will
+        will be expanded into variable containing the underlying value. The expression is used in a
+        return statement, i.e. `return <expression(value)>;`.
+
+    - `from_custom` (required) - an expression to convert from the custom type into underlying type. `{}` will
+        will be expanded into variable containing the custom value. The expression is used in a
+        return statement, i.e. `return <expression(value);>`.
+
+- `go_mod` (optional) - Specify the go module for the final package, used as imports source for external types.
+
+- `c_module_filename`(optional) - override the name of the `C` module (`.h` and `.c`)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,7 +14,7 @@ v0.2.0+v0.25.0
 
 ## Update version in [bindgen/Cargo.toml](../bindgen/Cargo.toml)
 
-Note that the version in [bindgen/Cargo.toml](../bindgen/Cargo.toml) does is not prefixed with `v`,
+Note that the version in [bindgen/Cargo.toml](../bindgen/Cargo.toml) is not prefixed with `v`,
 i.e. `0.2.0+v0.25.0` instead of `v0.2.0+v0.25.0`.
 
 ## Update version in [Cargo.lock](../Cargo.lock)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,44 @@
+## Figure out next version
+
+Following [versioning rules](../README.md/#versioning), figure
+out the version to be made. If there were any breaking changes since last version, bump the minor
+component. If there weren't any breaking changes, bump the patch component.
+
+The version follows semver, and consists of `uniffi-bindgen-go` base version, followed by
+upstream `uniffi-rs` version in the build metadata component (denoted as `+`). The upstream explicit
+upstream `uniffi-rs` aids consumer to target the same upstream version when mixing multiple
+generators, e.g. `uniffi-bindgen-cs` and `uniffi-bindgen-go`.
+```
+v0.2.0+v0.25.0
+```
+
+## Update version in [bindgen/Cargo.toml](../bindgen/Cargo.toml)
+
+Note that the version in [bindgen/Cargo.toml](../bindgen/Cargo.toml) does is not prefixed with `v`,
+i.e. `0.2.0+v0.25.0` instead of `v0.2.0+v0.25.0`.
+
+## Update version in [Cargo.lock](../Cargo.lock)
+
+Run any `cargo` command to include the new version in `Cargo.lock` file, e.g.
+```
+cargo build
+```
+
+## Update version in [README.md](../README.md)
+
+- Update the [installation command](../README.md#how-to-install) to use the new version.
+- If upstream uniffi-rs version was updated, add new entry to [versioning table](../README.md#versioning).
+
+## Update [CHANGELOG.md](../CHANGELOG.md)
+
+Inspect Git history, create a list of changes since last version.
+- For breaking changes, prefix the change with `**BREAKING**:`
+- For important changes, such as memory leak or race condition fixes, prefix the change with `**IMPORTANT**:`
+
+## Create PR
+
+Create PR, get the PR reviewed, and merge into `main`.
+
+## Create tag
+
+Once the PR is merged into `main`, create new tag in `main` branch.


### PR DESCRIPTION
Create `docs/RELEASE.md` containing the release procedure.

Refactor configuration options from `README.md` into `docs/CONFIGURATION.md`.