### PR TITLE
bugfix: ensure field names and error interface function don't clash

### DIFF
--- a/bindgen/src/gen_go/mod.rs
+++ b/bindgen/src/gen_go/mod.rs
@@ -431,6 +431,12 @@ pub mod filters {
 
     /// Get the idiomatic Go rendering of a struct field name.
     pub fn field_name(nm: &str) -> Result<String, askama::Error> {
+        // Fields called 'Error' can clash with structs which implement the error
+        // interface, causing a compilation error. Suffix with _ similar to reserved
+        // keywords in var names.
+        if nm == "error" {
+            return Ok(String::from("Error_"));
+        }
         Ok(nm.to_string().to_upper_camel_case())
     }
 

--- a/bindgen/src/gen_go/mod.rs
+++ b/bindgen/src/gen_go/mod.rs
@@ -431,6 +431,10 @@ pub mod filters {
 
     /// Get the idiomatic Go rendering of a struct field name.
     pub fn field_name(nm: &str) -> Result<String, askama::Error> {
+        Ok(nm.to_string().to_upper_camel_case())
+    }
+
+    pub fn error_field_name(nm: &str) -> Result<String, askama::Error> {
         // Fields called 'Error' can clash with structs which implement the error
         // interface, causing a compilation error. Suffix with _ similar to reserved
         // keywords in var names.

--- a/bindgen/templates/ErrorTemplate.go
+++ b/bindgen/templates/ErrorTemplate.go
@@ -28,7 +28,7 @@ type {{ variant_class_name }} struct {
 	message string
 	{%- else %}
 	{%- for field in variant.fields() %}
-	{{ field.name()|field_name }} {{ field|type_name}}
+	{{ field.name()|error_field_name }} {{ field|type_name}}
 	{%- endfor %}
 	{%- endif %}
 }
@@ -44,7 +44,7 @@ func New{{ variant_class_name }}(
 		err: &{{ variant_class_name }}{
 		{%- if !e.is_flat() %}
 		{%- for field in variant.fields() %}
-			{{ field.name()|field_name }}: {{ field.name()|var_name }},
+			{{ field.name()|error_field_name }}: {{ field.name()|var_name }},
 		{%- endfor %}
 		{%- endif %}
 		},
@@ -60,8 +60,8 @@ func (err {{ variant_class_name }}) Error() string {
 		{% if !variant.fields().is_empty() %}": ",{% endif %}
 		{%- for field in variant.fields() %}
 		{% if !loop.first %}", ",{% endif %}
-		"{{ field.name()|field_name }}=",
-		err.{{ field.name()|field_name }},
+		"{{ field.name()|error_field_name }}=",
+		err.{{ field.name()|error_field_name }},
 		{%- endfor %}
 	)
 }
@@ -107,7 +107,7 @@ func (c {{ e|ffi_converter_name }}) Read(reader io.Reader) error {
 	case {{ loop.index }}:
 		return &{{ type_name|class_name }}{&{{ type_name|class_name }}{{ variant.name()|class_name }}{
 			{%- for field in variant.fields() %}
-			{{ field.name()|field_name }}: {{ field|read_fn }}(reader),
+			{{ field.name()|error_field_name }}: {{ field|read_fn }}(reader),
 			{%- endfor %}
 		}}
 	{%- endfor %}
@@ -124,7 +124,7 @@ func (c {{ e|ffi_converter_name }}) Write(writer io.Writer, value *{{ type_name|
 		case *{{ type_name }}{{ variant.name()|class_name }}:
 			writeInt32(writer, {{ loop.index }})
 			{%- for field in variant.fields() %}
-			{{ field|write_fn }}(writer, variantValue.{{ field.name()|field_name }})
+			{{ field|write_fn }}(writer, variantValue.{{ field.name()|error_field_name }})
 			{%- endfor %}
 		{%- endfor %}
 		default:

--- a/binding_tests/errors_test.go
+++ b/binding_tests/errors_test.go
@@ -149,4 +149,5 @@ func TestErrorNamedError(t *testing.T) {
 	err := errors.NewErrorNamedErrorError("it's an error")
 	var expectedError *errors.ErrorNamedError
 	assert.ErrorAs(t, err, &expectedError)
+	assert.Equal(t, "it's an error", expectedError.Unwrap().(*errors.ErrorNamedErrorError).Error_)
 }

--- a/binding_tests/errors_test.go
+++ b/binding_tests/errors_test.go
@@ -141,3 +141,12 @@ func TestComplexErrorAsBase(t *testing.T) {
 	assert.ErrorAs(t, err, &expectedError)
 	assert.EqualError(t, expectedError, "ValidationError: InvalidUserAndMessage: UserId=100, Message=byebye")
 }
+
+func TestErrorNamedError(t *testing.T) {
+	// this test exists to ensure ErrorNamedError is not removed from the UDL without causing test failures.
+	// The purpose of ErrorNamedError is to ensure that the generated bindings produce compilable Go code,
+	// so there isn't really anything to actually test at runtime.
+	err := errors.NewErrorNamedErrorError("it's an error")
+	var expectedError *errors.ErrorNamedError
+	assert.ErrorAs(t, err, &expectedError)
+}

--- a/fixtures/errors/src/errors.udl
+++ b/fixtures/errors/src/errors.udl
@@ -28,6 +28,11 @@ interface ValidationError {
 };
 
 [Error]
+interface ErrorNamedError {
+  Error(string error);
+};
+
+[Error]
 interface ComplexError {
     Struct(Vec2 position_a, Vec2 position_b);
     List(sequence<Vec2> list);

--- a/fixtures/errors/src/lib.rs
+++ b/fixtures/errors/src/lib.rs
@@ -25,6 +25,12 @@ pub enum ValidationError {
 }
 
 #[derive(Debug, thiserror::Error)]
+pub enum ErrorNamedError {
+    #[error("Error {error}")]
+    Error { error: String },
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum ComplexError {
     #[error("Struct")]
     Struct { position_a: Vec2, position_b: Vec2 },


### PR DESCRIPTION
Fixes https://github.com/NordSecurity/uniffi-bindgen-go/issues/30

Signed-off-by: `Kegan Dougal <7190048+kegsay@users.noreply.github.com>`