### PR TITLE
added section on linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bin
 ```
 uniffi-bindgen-go path/to/definitions.udl
 ```
+
 Generates bindings file `path/to/uniffi/definitions/definitions.go`
+
+# Linking 
+
+You will need to make sure the compiled Rust binaries are in your `LD_LIBRARY_PATH` (set this to `target/release/` if you have built with the `--release` flag, for instance).
+
+You can also create a script to properly link these bindings - see `test_bindings.sh` in the root of this repository for an example. 
 
 # How to integrate bindings
 


### PR DESCRIPTION
In light of the example shell script that already exists in the root of the repository, and the different ways in which people might want to perform the linking (in a script, with env vars, etc) I opted to just add a minimal note to the readme reminding people that linking is necessary. 

re. #38 