### PR TITLE
Add support for MacOS build on sample build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
 set -euxo pipefail
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+ARCH=$(arch)
+
+if [[ "$ARCH" == "arm64" ]]; then
+cargo build --package uniffi-bindgen-go --package uniffi-bindgen-go-fixtures --target aarch64-apple-darwin
+else
+cargo build --package uniffi-bindgen-go --package uniffi-bindgen-go-fixtures --target x86_64-apple-darwin
+fi
+
+else
 cargo build --package uniffi-bindgen-go --package uniffi-bindgen-go-fixtures
+fi

--- a/build_bindings.sh
+++ b/build_bindings.sh
@@ -4,8 +4,21 @@ set -euxo pipefail
 SCRIPT_DIR="${SCRIPT_DIR:-$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )}"
 ROOT_DIR="$SCRIPT_DIR"
 
-BINDINGS_DIR="$ROOT_DIR/binding_tests/generated"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+ARCH=$(arch)
+
+if [[ "$ARCH" == "arm64" ]]; then
+TARGET="aarch64-apple-darwin"
+else
+TARGET="x86_64-apple-darwin"
+fi
+
+BINARIES_DIR="$ROOT_DIR/target/$TARGET/debug"
+else 
 BINARIES_DIR="$ROOT_DIR/target/debug"
+fi
+
+BINDINGS_DIR="$ROOT_DIR/binding_tests/generated"
 
 rm -rf $BINDINGS_DIR
 mkdir $BINDINGS_DIR
@@ -18,4 +31,4 @@ LIB_FILE="$BINARIES_DIR/libuniffi_fixtures.dylib"
 else 
 LIB_FILE="$BINARIES_DIR/libuniffi_fixtures.so"
 fi
-target/debug/uniffi-bindgen-go $LIB_FILE --out-dir "$BINDINGS_DIR" --library --config "$ROOT_DIR/fixtures/uniffi.toml"
+$BINARIES_DIR/uniffi-bindgen-go $LIB_FILE --out-dir "$BINDINGS_DIR" --library --config "$ROOT_DIR/fixtures/uniffi.toml"

--- a/test_bindings.sh
+++ b/test_bindings.sh
@@ -4,8 +4,23 @@ set -euxo pipefail
 SCRIPT_DIR="${SCRIPT_DIR:-$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )}"
 ROOT_DIR="$SCRIPT_DIR"
 
-BINDINGS_DIR="$ROOT_DIR/binding_tests"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+ARCH=$(arch)
+
+if [[ "$ARCH" == "arm64" ]]; then
+TARGET="aarch64-apple-darwin"
+else
+TARGET="x86_64-apple-darwin"
+fi
+
+
+BINARIES_DIR="$ROOT_DIR/target/$TARGET/debug"
+else 
 BINARIES_DIR="$ROOT_DIR/target/debug"
+fi
+
+BINDINGS_DIR="$ROOT_DIR/binding_tests"
 
 pushd $BINDINGS_DIR
 LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:$BINARIES_DIR" \


### PR DESCRIPTION
closes #50

This adds a few conditionals on `build.sh`, `build_bindings.sh` and `test_bindings.sh` to detect MacOS as host architecture and change build paths.

For some reason cargo ends up building intel 64-bit on Apple silicon instead of arm64 if no target is specified. This makes the scripts less simple but will work for anyone regardless whether they are building on Linux or MacOS.