### PR TITLE
test: Fix the Go version in the Docker image

### DIFF
--- a/docker_test_bindings.sh
+++ b/docker_test_bindings.sh
@@ -7,4 +7,4 @@ docker run \
     --volume $HOME/.cache/go-build:/root/.cache/go-build \
     --volume $PWD:/mounted_workdir \
     --workdir /mounted_workdir \
-    golang:1.19 ./test_bindings.sh
+    golang:1.20 ./test_bindings.sh


### PR DESCRIPTION
Closes https://github.com/NordSecurity/uniffi-bindgen-go/issues/54. See this related issue to get the problem description.