### PR TITLE
Cleanup callback code and test callback lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
  "uniffi-fixture-type-limits",
  "uniffi-go-fixture-destroy",
  "uniffi-go-fixture-errors",
+ "uniffi-go-fixture-issue43",
  "uniffi-go-fixture-issue45",
  "uniffi-go-fixture-name-case",
  "uniffi-go-fixture-objects",
@@ -1443,6 +1444,16 @@ version = "1.0.0"
 dependencies = [
  "thiserror",
  "uniffi",
+ "uniffi_build",
+ "uniffi_macros",
+]
+
+[[package]]
+name = "uniffi-go-fixture-issue43"
+version = "1.0.0"
+dependencies = [
+ "uniffi",
+ "uniffi-go-fixture-issue45",
  "uniffi_build",
  "uniffi_macros",
 ]

--- a/binding_tests/issue45_test.go
+++ b/binding_tests/issue45_test.go
@@ -6,8 +6,8 @@ package binding_tests
 
 import (
 	"github.com/NordSecurity/uniffi-bindgen-go/binding_tests/generated/issue45"
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 // Ensure multiple futures packages work fine together, the other one being


### PR DESCRIPTION
1) Test callback lifetime. Equivalent of https://github.com/mozilla/uniffi-rs/pull/2230

The code looks like it should have the equivalent issue as https://github.com/NordSecurity/uniffi-bindgen-cs/issues/79, but because pointers were taken to local variables, each pointer was unique, and received a unique handle.

2) Store generic type directly in concurrentHandleMap, not via pointer. Remove `rightMap`, as it actually doesn't do anything, and only creates issues. (https://github.com/NordSecurity/uniffi-bindgen-cs/issues/79)