### PR TITLE
fix panic when reading empty string or bytes from unify-rs

### DIFF
--- a/bindgen/templates/BytesHelper.go
+++ b/bindgen/templates/BytesHelper.go
@@ -35,7 +35,7 @@ func (c FfiConverterBytes) Read(reader io.Reader) []byte {
 	length := readInt32(reader)
 	buffer := make([]byte, length)
 	read_length, err := reader.Read(buffer)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		panic(err)
 	}
 	if read_length != int(length) {

--- a/bindgen/templates/StringHelper.go
+++ b/bindgen/templates/StringHelper.go
@@ -22,7 +22,7 @@ func ({{ ffi_converter_name }}) Read(reader io.Reader) string {
 	length := readInt32(reader)
 	buffer := make([]byte, length)
 	read_length, err := reader.Read(buffer)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		panic(err)
 	}
 	if read_length != int(length) {


### PR DESCRIPTION
Consider the code like the following:
```rust
#[uniffi::export]
fn empty_string_test() -> Option<String> {
    Some(String::new())
}

#[uniffi::export]
fn empty_bytes_test() -> Option<Vec<u8>> {
    Some(vec![])
}

uniffi::setup_scaffolding!();
```

And call them like this:
```go
func Test_empty_message(t *testing.T) {
	if *EmptyStringTest() != "" {
		t.Error("EmptyStringTest() should return empty string")
	}
}

func Test_empty_bytes(t *testing.T) {
	if len(*EmptyBytesTest()) != 0 {
		t.Error("EmptyStringTest() should return empty string")
	}
}
```

It will panic like this:
```
panic: EOF [recovered]
	panic: EOF
```