### PR TITLE
Rework error implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "anstream"
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "async-compat"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68a707c1feb095d8c07f8a65b9f506b117d30af431cab89374357de7c11461b"
+checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -193,14 +193,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -283,9 +284,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.87"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -306,17 +307,17 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -339,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blocking"
@@ -398,15 +399,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -548,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -575,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
@@ -719,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -831,9 +823,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
@@ -889,11 +881,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -917,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -950,9 +942,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1012,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -1205,9 +1197,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -1937,9 +1929,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "value-bag"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "version_check"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all: build generate test
+
+build:
+	./build.sh
+
+generate:
+	./build_bindings.sh
+
+test:
+	./test_bindings.sh

--- a/bindgen/templates/macros.go
+++ b/bindgen/templates/macros.go
@@ -15,14 +15,14 @@
 	{%- when Some with (return_type) -%}
 		{%- match func.throws_type() -%}
 		{%- when Some with (throws_type) -%}
-		({{ return_type|type_name(ci) }}, {{ throws_type|type_name(ci) }})
+		({{ return_type|type_name(ci) }}, error)
 		{%- when None -%}
 		{{ return_type|type_name(ci) }}
 		{%- endmatch %}
 	{%- when None -%}
 		{%- match func.throws_type() -%}
 		{%- when Some with (throws_type) -%}
-		{{ throws_type|type_name(ci) }}
+		error
 		{%- when None -%}
 		{%- endmatch %}
 	{%- endmatch %}
@@ -38,7 +38,7 @@
 			var _uniffiDefaultValue {{ return_type|type_name(ci) }}
 			return _uniffiDefaultValue, _uniffiErr
 		} else {
-			return {{ return_type|lift_fn }}(_uniffiRV), _uniffiErr
+			return {{ return_type|lift_fn }}(_uniffiRV), nil
 		}
 		{%- when None -%}
 		return {{ return_type|lift_fn }}({% call to_ffi_call(func, prefix) %})
@@ -47,7 +47,7 @@
 		{%- match func.throws_type() -%}
 		{%- when Some with (throws_type) -%}
 		_, _uniffiErr := {% call to_ffi_call(func, prefix) %}
-		return _uniffiErr
+		return _uniffiErr.AsError()
 		{%- when None -%}
 		{% call to_ffi_call(func, prefix) %}
 		{%- endmatch -%}
@@ -164,7 +164,7 @@
 		// liftFn
 		func(_ struct{}) struct{} { return struct{}{} },
     {%- when (Some(return_type), None) -%}
-	uniffiRustCallAsync[struct{}](
+	uniffiRustCallAsync[error](
         nil,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) {{ return_type|ffi_type_name }} {
@@ -176,7 +176,7 @@
 			return {{ return_type|lift_fn }}(ffi)
 		},
     {%- when (None, None) -%}
-	uniffiRustCallAsync[struct{}](
+	uniffiRustCallAsync[error](
         nil,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {

--- a/binding_tests/callbacks_test.go
+++ b/binding_tests/callbacks_test.go
@@ -21,14 +21,14 @@ type OnCallAnswerImpl struct {
 	ignored string
 }
 
-func (c *OnCallAnswerImpl) Answer() (string, *callbacks.TelephoneError) {
+func (c *OnCallAnswerImpl) Answer() (string, error) {
 	c.answerCount += 1
 	return fmt.Sprintf("hello, %d", c.answerCount), nil
 }
 
 type OnCallAnswerBusyImpl struct{}
 
-func (OnCallAnswerBusyImpl) Answer() (string, *callbacks.TelephoneError) {
+func (OnCallAnswerBusyImpl) Answer() (string, error) {
 	return "", callbacks.NewTelephoneErrorBusy()
 }
 

--- a/binding_tests/coverall_test.go
+++ b/binding_tests/coverall_test.go
@@ -254,7 +254,7 @@ func (g *GoGetters) GetBool(v bool, arg2 bool) bool {
 	return v != arg2
 }
 
-func (g *GoGetters) GetString(v string, arg2 bool) (string, *coverall.CoverallError) {
+func (g *GoGetters) GetString(v string, arg2 bool) (string, error) {
 	switch v {
 	case "too-many-holes":
 		return "", coverall.NewCoverallErrorTooManyHoles()
@@ -268,7 +268,7 @@ func (g *GoGetters) GetString(v string, arg2 bool) (string, *coverall.CoverallEr
 	return v, nil
 }
 
-func (g *GoGetters) GetOption(v string, arg2 bool) (*string, *coverall.ComplexError) {
+func (g *GoGetters) GetOption(v string, arg2 bool) (*string, error) {
 	switch v {
 	case "os-error":
 		return nil, coverall.NewComplexErrorOsError(100, 200)

--- a/binding_tests/futures_test.go
+++ b/binding_tests/futures_test.go
@@ -161,7 +161,7 @@ func (gap *goAsyncParser) AsString(delayMs int32, value int32) string {
 	return fmt.Sprintf("%d", value)
 }
 
-func (gap *goAsyncParser) TryFromString(delayMs int32, value string) (int32, *ParserError) {
+func (gap *goAsyncParser) TryFromString(delayMs int32, value string) (int32, error) {
 	time.Sleep(time.Duration(delayMs) * time.Millisecond)
 	if value == "force-unexpected-exception" {
 		return 0, NewParserErrorUnexpectedError()
@@ -178,7 +178,7 @@ func (gap *goAsyncParser) Delay(delayMs int32) {
 	gap.completedDelays += 1
 }
 
-func (gap *goAsyncParser) TryDelay(delayMs string) *ParserError {
+func (gap *goAsyncParser) TryDelay(delayMs string) error {
 	ms, err := strconv.ParseInt(delayMs, 10, 32)
 	if err != nil {
 		return NewParserErrorNotAnInt()

--- a/binding_tests/proc_macro_test.go
+++ b/binding_tests/proc_macro_test.go
@@ -110,7 +110,7 @@ func (c GoTestCallbackInterface) WithBytes(rwb RecordWithBytes) []byte {
 	return rwb.SomeBytes
 }
 
-func (c GoTestCallbackInterface) TryParseInt(value string) (uint32, *BasicError) {
+func (c GoTestCallbackInterface) TryParseInt(value string) (uint32, error) {
 	if value == "force-unexpected-error" {
 		// raise an error that's not expected
 		return 0, NewBasicErrorUnexpectedError("some other error")


### PR DESCRIPTION
Avoid interface-nil trap by returning generic error instead of custom one, leaving the developer the posibility to cast it if needed.