### PR TITLE
Upgrade to uniffi v0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v0.6.0+v0.30.0
+- **BREAKING** Upgrade to `uniffi-rs` v0.30.0
+- Update object handles to match `uniffi`'s `uint64` FFI representation
+- Adapt generated bindings for `uniffi` v0.30.0 API changes, including async helpers and callback interfaces
+
 ### v0.5.0+v0.29.5
 - **BREAKING** Upgrade to `uniffi-rs` v0.29.5
 - **BREAKING** Bump MSRV to 1.85

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -843,19 +845,19 @@ dependencies = [
 [[package]]
 name = "large-enum"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "large-error"
 version = "0.26.1"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
@@ -1127,6 +1129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,12 +1286,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "unicode-ident"
@@ -1302,38 +1343,38 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "uniffi"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
+checksum = "c866f627c3f04c3df068b68bb2d725492caaa539dd313e2a9d26bb85b1a32f4e"
 dependencies = [
  "anyhow",
  "camino",
  "cargo_metadata",
  "clap",
- "uniffi_bindgen 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_core 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi"
-version = "0.29.5"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "uniffi_bindgen 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
- "uniffi_build 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
- "uniffi_core 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
- "uniffi_macros 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
- "uniffi_pipeline 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi_bindgen 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_build 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_core 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-bindgen-go"
-version = "0.5.0+v0.29.5"
+version = "0.6.0+v0.30.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -1348,9 +1389,9 @@ dependencies = [
  "serde_json",
  "textwrap",
  "toml",
- "uniffi_bindgen 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_udl 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1396,140 +1437,140 @@ dependencies = [
 [[package]]
 name = "uniffi-example-arithmetic"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-callbacks"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-custom-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
  "url",
 ]
 
 [[package]]
 name = "uniffi-example-futures"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "async-std",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-geometry"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-rondpoint"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-sprites"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-todolist"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "once_cell",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-example-traits"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-callbacks"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-coverall"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "once_cell",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-docstring"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-enum-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-error-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-ext-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-external-crate",
@@ -1541,38 +1582,38 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-ext-types-custom-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "bytes",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-ext-types-external-crate"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 
 [[package]]
 name = "uniffi-fixture-ext-types-lib-one"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "bytes",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-ext-types-proc-macro"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-lib-one",
@@ -1582,10 +1623,10 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-ext-types-sub-lib"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
  "uniffi-fixture-ext-types-lib-one",
 ]
 
@@ -1598,63 +1639,63 @@ dependencies = [
  "once_cell",
  "thiserror 1.0.69",
  "tokio",
- "uniffi 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-fixture-proc-macro"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "lazy_static",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-simple-fns"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-simple-iface"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "lazy_static",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-time"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "chrono",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-trait-methods"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "once_cell",
- "thiserror 1.0.69",
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "thiserror 2.0.17",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-type-limits"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
- "uniffi 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
@@ -1663,18 +1704,18 @@ version = "1.0.0"
 dependencies = [
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-go-fixture-empty-string-and-bytes"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1682,28 +1723,28 @@ name = "uniffi-go-fixture-errors"
 version = "1.0.0"
 dependencies = [
  "thiserror 1.0.69",
- "uniffi 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-go-fixture-issue43"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi-go-fixture-issue45",
- "uniffi_build 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-go-fixture-issue45"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1712,8 +1753,8 @@ version = "0.22.0"
 dependencies = [
  "glob",
  "thiserror 1.0.69",
- "uniffi 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_bindgen 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_testing",
 ]
 
@@ -1724,16 +1765,16 @@ dependencies = [
  "crossbeam",
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
+checksum = "7c8ca600167641ebe7c8ba9254af40492dda3397c528cc3b2f511bd23e8541a5"
 dependencies = [
  "anyhow",
  "askama",
@@ -1749,17 +1790,17 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml",
- "uniffi_internal_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_testing",
- "uniffi_udl 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.5"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "askama",
@@ -1775,38 +1816,38 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml",
- "uniffi_internal_macros 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
- "uniffi_meta 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
- "uniffi_pipeline 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
- "uniffi_udl 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_udl 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025a05cba02ee22b6624ac3d257e59c7395319ea8fe1aae33a7cdb4e2a3016cc"
+checksum = "3e55c05228f4858bb258f651d21d743fcc1fe5a2ec20d3c0f9daefddb105ee4d"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.29.5"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi_bindgen 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
+checksum = "7e7a5a038ebffe8f4cf91416b154ef3c2468b18e828b7009e01b1b99938089f9"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1817,8 +1858,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.5"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1828,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+checksum = "e3c2a6f93e7b73726e2015696ece25ca0ac5a5f1cf8d6a7ab5214dd0a01d2edf"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1841,8 +1882,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.5"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1853,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
+checksum = "64c6309fc36c7992afc03bc0c5b059c656bccbef3f2a4bc362980017f8936141"
 dependencies = [
  "camino",
  "fs-err",
@@ -1865,13 +1906,13 @@ dependencies = [
  "serde",
  "syn",
  "toml",
- "uniffi_meta 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.5"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "camino",
  "fs-err",
@@ -1881,62 +1922,62 @@ dependencies = [
  "serde",
  "syn",
  "toml",
- "uniffi_meta 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
+checksum = "0a138823392dba19b0aa494872689f97d0ee157de5852e2bec157ce6de9cdc22"
 dependencies = [
  "anyhow",
  "siphasher",
- "uniffi_internal_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.5"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "siphasher",
- "uniffi_internal_macros 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
- "uniffi_pipeline 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
+checksum = "8c27c4b515d25f8e53cc918e238c39a79c3144a40eaf2e51c4a7958973422c29"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap",
  "tempfile",
- "uniffi_internal_macros 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.29.5"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap",
  "tempfile",
- "uniffi_internal_macros 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
 name = "uniffi_testing"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de559b1c057a704080f320c204dfe611c68034c801fc9b86a83d36b565ca7482"
+checksum = "a4adb08eb5589849231dc0626ba0f9a1297925fd751f0740fc630ae934dd9c5e"
 dependencies = [
  "anyhow",
  "camino",
@@ -1947,25 +1988,25 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.5"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
+checksum = "d0adacdd848aeed7af4f5af7d2f621d5e82531325d405e29463482becfdeafca"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta 0.29.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle2 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.5"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+version = "0.30.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta 0.29.5 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
- "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5)",
+ "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
 ]
 
 [[package]]
@@ -2087,7 +2128,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.29.5#856f77b6fdf78fae45bc3c394499df60f8cc5851"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ members = [
 ]
 
 [workspace.dependencies]
-uniffi = "0.29.5"
-uniffi_testing = "0.29.5"
-uniffi_macros = "0.29.5"
-uniffi_build = { version = "0.29.5", features=["builtin-bindgen"] }
-uniffi_bindgen = "0.29.5"
-uniffi_meta = "0.29.5"
-uniffi_udl = "0.29.5"
+uniffi = "0.30.0"
+uniffi_testing = "0.30.0"
+uniffi_macros = "0.30.0"
+uniffi_build = { version = "0.30.0", features=["builtin-bindgen"] }
+uniffi_bindgen = "0.30.0"
+uniffi_meta = "0.30.0"
+uniffi_udl = "0.30.0"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Generate [UniFFI](https://github.com/mozilla/uniffi-rs) bindings for Go. `uniffi-bindgen-go` lives
 as a separate project from `uniffi-go`, as per
 [uniffi-rs #1355](https://github.com/mozilla/uniffi-rs/issues/1355). Currently, `uniffi-bindgen-go`
-uses `uniffi-rs` version `0.29.5`.
+uses `uniffi-rs` version `0.30.0`.
 
 # How to install
 
@@ -11,7 +11,7 @@ Minimum Rust version required to install `uniffi-bindgen-go` is `1.85`.
 Newer Rust versions should also work fine.
 
 ```
-cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.5.0+v0.29.5
+cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.6.0+v0.30.0
 ```
 
 # How to generate bindings
@@ -63,10 +63,13 @@ To simplify this choice `uniffi-bindgen-cs` and `uniffi-bindgen-go` use tag nami
 as follows: `vX.Y.Z+vA.B.C`, where `X.Y.Z` is the version of the generator itself, and `A.B.C` is
 the version of uniffi-rs it is based on.
 
-The table shows `uniffi-rs` version history for tags that were published before tag naming convention described above was introduced.
+The table shows the `uniffi-rs` version targeted by each published `uniffi-bindgen-go` release.
 
 | uniffi-bindgen-go version                | uniffi-rs version                                |
 |------------------------------------------|--------------------------------------------------|
+| v0.6.0                                   | v0.30.0                                          |
+| v0.5.0                                   | v0.29.5                                          |
+| v0.4.0                                   | v0.28.3                                          |
 | v0.3.0                                   | v0.28.3                                          |
 | v0.2.0                                   | v0.25.0                                          |
 | v0.1.0                                   | v0.23.0                                          |

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-go"
-version = "0.5.0+v0.29.5"
+version = "0.6.0+v0.30.0"
 edition = "2021"
 
 [lib]
@@ -19,7 +19,7 @@ extend = "1.1"
 heck = "0.5"
 cargo_metadata = "0.19"
 serde = "1"
-toml = "0.5"
+toml = "0.9"
 camino = "1.0.8"
 fs-err = "2.7.0"
 paste = "1.0"

--- a/bindgen/src/gen_go/callback_interface.rs
+++ b/bindgen/src/gen_go/callback_interface.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 use super::CodeType;
 

--- a/bindgen/src/gen_go/compounds.rs
+++ b/bindgen/src/gen_go/compounds.rs
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use paste::paste;
-use uniffi_bindgen::{backend::Literal, interface::Type, ComponentInterface};
+use uniffi_bindgen::{
+    interface::{Literal, Type},
+    ComponentInterface,
+};
 
 use super::CodeType;
 

--- a/bindgen/src/gen_go/custom.rs
+++ b/bindgen/src/gen_go/custom.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 use super::CodeType;
 

--- a/bindgen/src/gen_go/enum_.rs
+++ b/bindgen/src/gen_go/enum_.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 use super::{filters::oracle, CodeType};
 

--- a/bindgen/src/gen_go/external.rs
+++ b/bindgen/src/gen_go/external.rs
@@ -2,46 +2,212 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use uniffi_bindgen::ComponentInterface;
+use uniffi_bindgen::{
+    interface::{FfiType, Type},
+    ComponentInterface,
+};
 
-use super::CodeType;
+use super::{filters::oracle, CodeType};
 
 #[derive(Debug)]
 pub struct ExternalCodeType {
     name: String,
     namespace: String,
-    is_object: bool,
+    kind: ExternalKind,
+    is_error: bool,
+    custom_builtin: Option<Type>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CustomFfiType {
+    plain: &'static str,
+    cgo: &'static str,
+    needs_lower_external: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternalKind {
+    Value,
+    Object,
+    Interface,
 }
 
 impl ExternalCodeType {
-    pub fn new(name: String, namespace: String, is_object: bool) -> Self {
-        ExternalCodeType { name, namespace, is_object }
+    pub fn new(
+        name: String,
+        namespace: String,
+        kind: ExternalKind,
+        is_error: bool,
+        custom_builtin: Option<Type>,
+    ) -> Self {
+        ExternalCodeType {
+            name,
+            namespace,
+            kind,
+            is_error,
+            custom_builtin,
+        }
+    }
+
+    fn rendered_type_label(&self) -> String {
+        let label = format!("{}.{}", self.namespace, self.canonical_name());
+        match self.kind {
+            ExternalKind::Value | ExternalKind::Interface if self.is_error => format!("*{}", label),
+            ExternalKind::Value | ExternalKind::Interface => label,
+            ExternalKind::Object => format!("*{}", label),
+        }
+    }
+
+    fn helper_stem(&self) -> String {
+        if self.custom_builtin.is_some() {
+            format!("Type{}", self.canonical_name())
+        } else {
+            self.canonical_name()
+        }
+    }
+
+    fn custom_ffi_type(&self) -> Option<CustomFfiType> {
+        let builtin = self.custom_builtin.as_ref()?;
+        Some(match FfiType::from(builtin) {
+            FfiType::Int8 => CustomFfiType {
+                plain: "int8",
+                cgo: "C.int8_t",
+                needs_lower_external: false,
+            },
+            FfiType::UInt8 => CustomFfiType {
+                plain: "uint8",
+                cgo: "C.uint8_t",
+                needs_lower_external: false,
+            },
+            FfiType::Int16 => CustomFfiType {
+                plain: "int16",
+                cgo: "C.int16_t",
+                needs_lower_external: false,
+            },
+            FfiType::UInt16 => CustomFfiType {
+                plain: "uint16",
+                cgo: "C.uint16_t",
+                needs_lower_external: false,
+            },
+            FfiType::Int32 => CustomFfiType {
+                plain: "int32",
+                cgo: "C.int32_t",
+                needs_lower_external: false,
+            },
+            FfiType::UInt32 => CustomFfiType {
+                plain: "uint32",
+                cgo: "C.uint32_t",
+                needs_lower_external: false,
+            },
+            FfiType::Int64 => CustomFfiType {
+                plain: "int64",
+                cgo: "C.int64_t",
+                needs_lower_external: false,
+            },
+            FfiType::UInt64 => CustomFfiType {
+                plain: "uint64",
+                cgo: "C.uint64_t",
+                needs_lower_external: false,
+            },
+            FfiType::Float32 => CustomFfiType {
+                plain: "float32",
+                cgo: "C.float",
+                needs_lower_external: false,
+            },
+            FfiType::Float64 => CustomFfiType {
+                plain: "float64",
+                cgo: "C.double",
+                needs_lower_external: false,
+            },
+            FfiType::RustBuffer(_) => CustomFfiType {
+                plain: "RustBufferI",
+                cgo: "RustBufferI",
+                needs_lower_external: true,
+            },
+            _ => return None,
+        })
     }
 }
 
 impl CodeType for ExternalCodeType {
     fn type_label(&self, _ci: &ComponentInterface) -> String {
-        let label = format!("{}.{}", self.namespace, self.name);
-        if self.is_object {
-            format!("*{}", label)
-        } else {
-            label
-        }
+        self.rendered_type_label()
     }
 
     fn canonical_name(&self) -> String {
-        self.name.clone()
+        oracle().class_name(&self.name)
     }
 
     fn ffi_converter_name(&self) -> String {
-        format!("{}.FfiConverter{}", self.namespace, self.canonical_name())
+        format!("{}.FfiConverter{}", self.namespace, self.helper_stem())
     }
 
     fn ffi_destroyer_name(&self) -> String {
-        format!("{}.FfiDestroyer{}", self.namespace, self.canonical_name())
+        format!("{}.FfiDestroyer{}", self.namespace, self.helper_stem())
+    }
+
+    fn lower(&self) -> String {
+        if let Some(ffi_type) = self.custom_ffi_type() {
+            return format!(
+                "func(value {}) {} {{ return {}({}.LowerToExternal{}(value)) }}",
+                self.rendered_type_label(),
+                ffi_type.cgo,
+                ffi_type.cgo,
+                self.namespace,
+                self.helper_stem(),
+            );
+        }
+        match self.kind {
+            ExternalKind::Value => format!("{}.Lower", self.ffi_converter_instance()),
+            ExternalKind::Object | ExternalKind::Interface => {
+                let type_label = self.rendered_type_label();
+                format!(
+                    "func(value {type_label}) C.uint64_t {{ return C.uint64_t({}.LowerToExternal{}(value)) }}",
+                    self.namespace,
+                    self.helper_stem()
+                )
+            }
+        }
+    }
+
+    fn lift(&self) -> String {
+        if let Some(ffi_type) = self.custom_ffi_type() {
+            return format!(
+                "func(value {}) {} {{ return {}.LiftFromExternal{}({}(value)) }}",
+                ffi_type.cgo,
+                self.rendered_type_label(),
+                self.namespace,
+                self.helper_stem(),
+                ffi_type.plain,
+            );
+        }
+        match self.kind {
+            ExternalKind::Value => format!("{}.Lift", self.ffi_converter_instance()),
+            ExternalKind::Object | ExternalKind::Interface => {
+                let type_label = self.rendered_type_label();
+                format!(
+                    "func(handle C.uint64_t) {type_label} {{ return {}.LiftFromExternal{}(uint64(handle)) }}",
+                    self.namespace,
+                    self.helper_stem()
+                )
+            }
+        }
+    }
+
+    fn lower_external(&self) -> String {
+        if self.custom_builtin.is_some() {
+            return format!("{}.LowerToExternal{}", self.namespace, self.helper_stem());
+        }
+        format!("{}.LowerExternal", self.ffi_converter_instance())
     }
 
     fn requires_lower_external(&self) -> bool {
-        !self.is_object
+        self.custom_builtin
+            .as_ref()
+            .and_then(|_| {
+                self.custom_ffi_type()
+                    .map(|ffi_type| ffi_type.needs_lower_external)
+            })
+            .unwrap_or(self.kind == ExternalKind::Value)
     }
 }

--- a/bindgen/src/gen_go/filters.rs
+++ b/bindgen/src/gen_go/filters.rs
@@ -167,7 +167,6 @@ pub fn cgo_callback_fn_name(
 pub fn ffi_type_name<T: Clone + Into<FfiType>>(type_: &T) -> Result<String, askama::Error> {
     let ffi_type: FfiType = type_.clone().into();
     let result = match ffi_type {
-        FfiType::RustArcPtr(_) => "unsafe.Pointer".into(),
         FfiType::RustBuffer(_) => "RustBufferI".into(),
         FfiType::VoidPointer => "*C.void".into(),
         FfiType::MutReference(inner) => format!("*{}", ffi_type_name(&*inner)?),
@@ -182,7 +181,6 @@ pub fn ffi_type_name_cgo_safe<T: Clone + Into<FfiType>>(
 ) -> Result<String, askama::Error> {
     let ffi_type: FfiType = type_.clone().into();
     let result = match ffi_type {
-        FfiType::RustArcPtr(_) => "unsafe.Pointer".into(),
         FfiType::RustBuffer(_) => "C.RustBuffer".into(),
         FfiType::VoidPointer => "*C.void".into(),
         FfiType::Reference(inner) => format!("*{}", ffi_type_name_cgo_safe(&*inner)?),

--- a/bindgen/src/gen_go/miscellany.rs
+++ b/bindgen/src/gen_go/miscellany.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use paste::paste;
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 use super::CodeType;
 

--- a/bindgen/src/gen_go/mod.rs
+++ b/bindgen/src/gen_go/mod.rs
@@ -493,7 +493,6 @@ impl GoCodeOracle {
             FfiType::UInt64 => "uint64_t".into(),
             FfiType::Float32 => "float".into(),
             FfiType::Float64 => "double".into(),
-            FfiType::RustArcPtr(_) => "void*".into(),
             FfiType::Handle => "uint64_t".into(),
             FfiType::VoidPointer => "void*".into(),
             FfiType::RustBuffer(_) => "RustBuffer".into(),

--- a/bindgen/src/gen_go/mod.rs
+++ b/bindgen/src/gen_go/mod.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Context, Result};
 use askama::Template;
-use external::ExternalCodeType;
+use external::{ExternalCodeType, ExternalKind};
 use heck::{ToLowerCamelCase, ToSnakeCase, ToUpperCamelCase};
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
@@ -277,6 +277,16 @@ impl<'config, 'ci> BridgingHeader<'config, 'ci> {
                 )
             };
 
+        let clone_callback =
+            |name: &str, module: &str| -> (String, Option<FfiType>, Vec<FfiArgument>, bool) {
+                (
+                    oracle().cgo_vtable_clone_fn_name(name, module),
+                    Some(FfiType::Handle),
+                    vec![FfiArgument::new("handle", FfiType::Handle)],
+                    false,
+                )
+            };
+
         let obj_callbacks = self
             .ci
             .object_definitions()
@@ -294,6 +304,7 @@ impl<'config, 'ci> BridgingHeader<'config, 'ci> {
             .chain(cbi_callbacks)
             .flat_map(|(module, name, vtable)| {
                 let free = free_callback(name, &module);
+                let clone = clone_callback(name, &module);
                 vtable
                     .into_iter()
                     .map(move |(ffi_cb, _)| {
@@ -304,7 +315,7 @@ impl<'config, 'ci> BridgingHeader<'config, 'ci> {
                             ffi_cb.has_rust_call_status_arg(),
                         )
                     })
-                    .chain([free])
+                    .chain([free, clone])
             })
             .collect()
     }
@@ -341,8 +352,31 @@ impl GoCodeOracle {
                 .namespace_for_module_path(&module_path)
                 .unwrap()
                 .to_string();
-            let is_object = matches!(type_, Type::Object { .. });
-            return Box::new(ExternalCodeType::new(name, namespace, is_object));
+            let kind = match &type_ {
+                Type::Object { imp, .. } if imp.is_trait_interface() => ExternalKind::Interface,
+                Type::Object { .. } => ExternalKind::Object,
+                Type::CallbackInterface { .. } => ExternalKind::Interface,
+                _ => ExternalKind::Value,
+            };
+            let is_error = matches!(type_, Type::Enum { .. }) && ci.is_name_used_as_error(&name);
+            let custom_builtin = match &type_ {
+                Type::Custom { builtin, .. }
+                    if !matches!(
+                        builtin.as_ref(),
+                        Type::Object { .. } | Type::CallbackInterface { .. }
+                    ) =>
+                {
+                    Some((**builtin).clone())
+                }
+                _ => None,
+            };
+            return Box::new(ExternalCodeType::new(
+                name,
+                namespace,
+                kind,
+                is_error,
+                custom_builtin,
+            ));
         }
 
         match type_ {
@@ -479,6 +513,11 @@ impl GoCodeOracle {
     /// Get cgo symbol name for a vtable free function
     fn cgo_vtable_free_fn_name(&self, nm: &str, module_path: &str) -> String {
         format!("{module_path}_cgo_dispatchCallbackInterface{nm}Free")
+    }
+
+    /// Get cgo symbol name for a vtable clone function
+    fn cgo_vtable_clone_fn_name(&self, nm: &str, module_path: &str) -> String {
+        format!("{module_path}_cgo_dispatchCallbackInterface{nm}Clone")
     }
 
     fn ffi_type_label(&self, ffi_type: &FfiType) -> String {

--- a/bindgen/src/gen_go/object.rs
+++ b/bindgen/src/gen_go/object.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 use uniffi_meta::ObjectImpl;
 
 use super::{filters::oracle, CodeType};

--- a/bindgen/src/gen_go/primitives.rs
+++ b/bindgen/src/gen_go/primitives.rs
@@ -4,7 +4,7 @@
 
 use paste::paste;
 use uniffi_bindgen::interface::{Radix, Type};
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 use super::CodeType;
 

--- a/bindgen/src/gen_go/record.rs
+++ b/bindgen/src/gen_go/record.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use uniffi_bindgen::{backend::Literal, ComponentInterface};
+use uniffi_bindgen::{interface::Literal, ComponentInterface};
 
 use super::CodeType;
 

--- a/bindgen/templates/Async.go
+++ b/bindgen/templates/Async.go
@@ -19,15 +19,15 @@ func {{ config|future_continuation_name }}(data C.uint64_t, pollResult C.int8_t)
 }
 
 func uniffiRustCallAsync[E any, T any, F any](
-	errConverter BufReader[*E],
+	errConverter BufReader[E],
 	completeFunc rustFutureCompleteFunc[F],
 	liftFunc func(F) T,
 	rustFuture C.uint64_t,
 	pollFunc rustFuturePollFunc,
 	freeFunc rustFutureFreeFunc,
-) (T, *E) {
+) (T, E) {
 	defer freeFunc(rustFuture)
-	
+
 	pollResult := int8(-1)
 	waiter := make(chan int8, 1)
 
@@ -43,17 +43,10 @@ func uniffiRustCallAsync[E any, T any, F any](
 		pollResult = <-waiter
 	}
 
-	var goValue T
-	var ffiValue F
-	var err *E
-	
-	ffiValue, err = rustCallWithError(errConverter, func(status *C.RustCallStatus) F {
-		return completeFunc(rustFuture, status)	
+	ffiValue, err := rustCallWithError(errConverter, func(status *C.RustCallStatus) F {
+		return completeFunc(rustFuture, status)
 	})
-	if err != nil {
-		return goValue, err
-	}
-	return liftFunc(ffiValue), nil
+	return liftFunc(ffiValue), err
 }
 
 //export {{ config|free_gorutine_callback }}

--- a/bindgen/templates/CallbackInterfaceTemplate.go
+++ b/bindgen/templates/CallbackInterfaceTemplate.go
@@ -39,6 +39,14 @@ func (c {{ ffi_converter_name }}) Write(writer io.Writer, value {{ type_name }})
 	writeUint64(writer, uint64(c.Lower(value)))
 }
 
+func LiftFromExternal{{ canonical_type_name }}(handle uint64) {{ type_name }} {
+	return {{ ffi_converter_instance }}.Lift(handle)
+}
+
+func LowerToExternal{{ canonical_type_name }}(value {{ type_name }}) uint64 {
+	return uint64({{ ffi_converter_instance }}.Lower(value))
+}
+
 type {{ ffi_destroyer_name }} struct {}
 
 func ({{ ffi_destroyer_name }}) Destroy(value {{ type_name }}) {}

--- a/bindgen/templates/CustomTypeTemplate.go
+++ b/bindgen/templates/CustomTypeTemplate.go
@@ -15,6 +15,30 @@ type {{ ffi_converter_name }} = {{ builtin|ffi_converter_name(ci) }}
 type {{ ffi_destroyer_name }} = {{ builtin|ffi_destroyer_name(ci) }}
 var {{ ffi_converter_instance }} = {{ builtin|ffi_converter_name(ci) }}{}
 
+{%- if !ci.is_external(builtin.as_ref()) %}
+{%- match builtin.as_ref() %}
+{%- when Type::Object { .. } | Type::CallbackInterface { .. } %}
+{%- else %}
+{%- if let FfiType::RustBuffer(_) = builtin.as_ref()|into_ffi_type %}
+func LiftFromExternal{{ canonical_type_name }}(value ExternalCRustBuffer) {{ name }} {
+	return {{ ffi_converter_instance }}.Lift(RustBufferFromExternal(value))
+}
+
+func LowerToExternal{{ canonical_type_name }}(value {{ name }}) ExternalCRustBuffer {
+	return RustBufferFromC({{ ffi_converter_instance }}.Lower(value))
+}
+{%- else %}
+func LiftFromExternal{{ canonical_type_name }}(value {{ builtin|type_name(ci) }}) {{ name }} {
+	return {{ ffi_converter_instance }}.Lift({{ builtin.as_ref()|ffi_type_name }}(value))
+}
+
+func LowerToExternal{{ canonical_type_name }}(value {{ name }}) {{ builtin|type_name(ci) }} {
+	return {{ builtin|type_name(ci) }}({{ ffi_converter_instance }}.Lower(value))
+}
+{%- endif %}
+{%- endmatch %}
+{%- endif %}
+
 {%- when Some with (config) %}
 
 {%- let ffi_type_name=builtin.as_ref()|ffi_type_name %}
@@ -58,6 +82,28 @@ func ({{ ffi_converter_name }}) Lift(value {{ ffi_type_name }}) {{ name }} {
 	builtinValue := {{ builtin|lift_fn(ci) }}(value)
 	{{ config.lift("builtinValue") }}
 }
+
+{%- match builtin.as_ref() %}
+{%- when Type::Object { .. } | Type::CallbackInterface { .. } %}
+{%- else %}
+{%- if let FfiType::RustBuffer(_) = builtin.as_ref()|into_ffi_type %}
+func LiftFromExternal{{ canonical_type_name }}(value ExternalCRustBuffer) {{ name }} {
+	return {{ ffi_converter_instance }}.Lift(RustBufferFromExternal(value))
+}
+
+func LowerToExternal{{ canonical_type_name }}(value {{ name }}) ExternalCRustBuffer {
+	return {{ ffi_converter_instance }}.Lower(value)
+}
+{%- else %}
+func LiftFromExternal{{ canonical_type_name }}(value {{ builtin|type_name(ci) }}) {{ name }} {
+	return {{ ffi_converter_instance }}.Lift({{ ffi_type_name }}(value))
+}
+
+func LowerToExternal{{ canonical_type_name }}(value {{ name }}) {{ builtin|type_name(ci) }} {
+	return {{ builtin|type_name(ci) }}({{ ffi_converter_instance }}.Lower(value))
+}
+{%- endif %}
+{%- endmatch %}
 
 func ({{ ffi_converter_name }}) Read(reader io.Reader) {{ name }} {
 	builtinValue := {{ builtin|read_fn(ci) }}(reader)

--- a/bindgen/templates/EnumTemplate.go
+++ b/bindgen/templates/EnumTemplate.go
@@ -50,6 +50,52 @@ func (e {{ type_name }}{{ variant.name()|class_name }}) Destroy() {
 
 {%- endif %}
 
+{%- if e.is_flat() %}
+{%- let trait_methods = e.uniffi_trait_methods() %}
+{%- if let Some(display_fmt) = trait_methods.display_fmt %}
+func (_self {{ type_name }}) String() string {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(display_fmt, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(debug_fmt) = trait_methods.debug_fmt %}
+func (_self {{ type_name }}) DebugString() string {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(debug_fmt, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(eq_eq) = trait_methods.eq_eq %}
+func (_self {{ type_name }}) Eq(other {{ type_name }}) bool {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(eq_eq, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(eq_ne) = trait_methods.eq_ne %}
+func (_self {{ type_name }}) Ne(other {{ type_name }}) bool {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(eq_ne, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(hash_hash) = trait_methods.hash_hash %}
+func (_self {{ type_name }}) Hash() uint64 {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(hash_hash, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(ord_cmp) = trait_methods.ord_cmp %}
+func (_self {{ type_name }}) Cmp(other {{ type_name }}) int8 {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(ord_cmp, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- endif %}
+
 type {{ ffi_converter_name }} struct {}
 
 var {{ ffi_converter_instance }} = {{ ffi_converter_name }}{}

--- a/bindgen/templates/EnumTemplate.go
+++ b/bindgen/templates/EnumTemplate.go
@@ -52,48 +52,9 @@ func (e {{ type_name }}{{ variant.name()|class_name }}) Destroy() {
 
 {%- if e.is_flat() %}
 {%- let trait_methods = e.uniffi_trait_methods() %}
-{%- if let Some(display_fmt) = trait_methods.display_fmt %}
-func (_self {{ type_name }}) String() string {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(display_fmt, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(debug_fmt) = trait_methods.debug_fmt %}
-func (_self {{ type_name }}) DebugString() string {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(debug_fmt, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(eq_eq) = trait_methods.eq_eq %}
-func (_self {{ type_name }}) Eq(other {{ type_name }}) bool {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(eq_eq, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(eq_ne) = trait_methods.eq_ne %}
-func (_self {{ type_name }}) Ne(other {{ type_name }}) bool {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(eq_ne, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(hash_hash) = trait_methods.hash_hash %}
-func (_self {{ type_name }}) Hash() uint64 {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(hash_hash, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(ord_cmp) = trait_methods.ord_cmp %}
-func (_self {{ type_name }}) Cmp(other {{ type_name }}) int8 {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(ord_cmp, "_selfBuf") %}
-}
-
-{%- endif %}
+{%- let receiver_type = type_name %}
+{%- let self_binding = "_selfBuf" %}
+{%- include "TraitMethods.go" %}
 {%- endif %}
 
 type {{ ffi_converter_name }} struct {}

--- a/bindgen/templates/Helpers.go
+++ b/bindgen/templates/Helpers.go
@@ -2,17 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */#}
 
-func rustCallWithError[E any, U any](converter BufReader[*E], callback func(*C.RustCallStatus) U) (U, *E) {
+func rustCallWithError[E any, U any](converter BufReader[E], callback func(*C.RustCallStatus) U) (U, E) {
 	var status C.RustCallStatus
 	returnValue := callback(&status)
 	err := checkCallStatus(converter, status)
 	return returnValue, err
 }
 
-func checkCallStatus[E any](converter BufReader[*E], status C.RustCallStatus) *E {
+func checkCallStatus[E any](converter BufReader[E], status C.RustCallStatus) E {
 	switch status.code {
 	case 0:
-		return nil
+		var zero E
+		return zero
 	case 1:
 		return LiftFromRustBuffer(converter, GoRustBuffer { inner: status.errorBuf })
 	case 2:

--- a/bindgen/templates/ObjectRuntime.go
+++ b/bindgen/templates/ObjectRuntime.go
@@ -62,6 +62,9 @@ func (ffiObject *FfiObject)destroy() {
 }
 
 func (ffiObject *FfiObject)freeRustArcPtr() {
+	if ffiObject.handle == 0 {
+		return
+	}
 	rustCall(func(status *C.RustCallStatus) int32 {
 		ffiObject.freeFunction(ffiObject.handle, status)
 		return 0

--- a/bindgen/templates/ObjectRuntime.go
+++ b/bindgen/templates/ObjectRuntime.go
@@ -9,26 +9,26 @@
 {{- self.add_import("sync/atomic") }}
 
 type FfiObject struct {
-	pointer unsafe.Pointer
+	handle C.uint64_t
 	callCounter atomic.Int64
-	cloneFunction func(unsafe.Pointer, *C.RustCallStatus) unsafe.Pointer
-	freeFunction func(unsafe.Pointer, *C.RustCallStatus)
+	cloneFunction func(C.uint64_t, *C.RustCallStatus) C.uint64_t
+	freeFunction func(C.uint64_t, *C.RustCallStatus)
 	destroyed atomic.Bool
 }
 
 func newFfiObject(
-	pointer unsafe.Pointer, 
-	cloneFunction func(unsafe.Pointer, *C.RustCallStatus) unsafe.Pointer, 
-	freeFunction func(unsafe.Pointer, *C.RustCallStatus),
+	handle C.uint64_t,
+	cloneFunction func(C.uint64_t, *C.RustCallStatus) C.uint64_t,
+	freeFunction func(C.uint64_t, *C.RustCallStatus),
 ) FfiObject {
 	return FfiObject {
-		pointer: pointer,
-		cloneFunction: cloneFunction, 
+		handle: handle,
+		cloneFunction: cloneFunction,
 		freeFunction: freeFunction,
 	}
 }
 
-func (ffiObject *FfiObject)incrementPointer(debugName string) unsafe.Pointer {
+func (ffiObject *FfiObject)incrementPointer(debugName string) C.uint64_t {
 	for {
 		counter := ffiObject.callCounter.Load()
 		if counter <= -1 {
@@ -42,8 +42,8 @@ func (ffiObject *FfiObject)incrementPointer(debugName string) unsafe.Pointer {
 		}
 	}
 
-	return rustCall(func(status *C.RustCallStatus) unsafe.Pointer {
-		return ffiObject.cloneFunction(ffiObject.pointer, status)
+	return rustCall(func(status *C.RustCallStatus) C.uint64_t {
+		return ffiObject.cloneFunction(ffiObject.handle, status)
 	})
 }
 
@@ -63,7 +63,7 @@ func (ffiObject *FfiObject)destroy() {
 
 func (ffiObject *FfiObject)freeRustArcPtr() {
 	rustCall(func(status *C.RustCallStatus) int32 {
-		ffiObject.freeFunction(ffiObject.pointer, status)
+		ffiObject.freeFunction(ffiObject.handle, status)
 		return 0
 	})
 }

--- a/bindgen/templates/ObjectTemplate.go
+++ b/bindgen/templates/ObjectTemplate.go
@@ -98,7 +98,7 @@ func (_self {{ impl_type_name }}) Hash() uint64 {
 }
 
 {% when UniffiTrait::Ord { cmp } %}
-func (_self {{ impl_type_name }}) Cmp(other {{ type_name }}) int32 {
+func (_self {{ impl_type_name }}) Cmp(other {{ type_name }}) int8 {
 	_pointer := _self.ffiObject.incrementPointer("{{ type_name }}")
 	defer _self.ffiObject.decrementPointer()
 	{% call go::ffi_call_binding(cmp, "_pointer") %}
@@ -145,6 +145,32 @@ func (_self {{impl_type_name}}) AsError() error {
 {% endif -%}
 
 func (c {{ ffi_converter_name }}) Lift(handle C.uint64_t) {{ type_name }} {
+	{%- if obj.has_callback_interface() %}
+	if uint64(handle) & 1 == 0 {
+		// Rust-generated handle (even), construct a new object wrapping the handle
+		result := &{{ impl_name }} {
+			newFfiObject(
+				handle,
+				func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+					return C.{{ obj.ffi_object_clone().name() }}(handle, status)
+				},
+				func(handle C.uint64_t, status *C.RustCallStatus) {
+					C.{{ obj.ffi_object_free().name() }}(handle, status)
+				},
+			),
+		}
+		runtime.SetFinalizer(result, ({{ impl_type_name }}).Destroy)
+		return result
+	} else {
+		// Go-generated handle (odd), retrieve from the handle map
+		val, ok := c.handleMap.tryGet(uint64(handle))
+		if !ok {
+			panic(fmt.Errorf("no callback in handle map: %d", handle))
+		}
+		c.handleMap.remove(uint64(handle))
+		return val
+	}
+	{%- else %}
 	result := &{{ impl_name }} {
 		newFfiObject(
 			handle,
@@ -158,6 +184,7 @@ func (c {{ ffi_converter_name }}) Lift(handle C.uint64_t) {{ type_name }} {
 	}
 	runtime.SetFinalizer(result, ({{ impl_type_name }}).Destroy)
 	return result
+	{%- endif %}
 }
 
 func (c {{ ffi_converter_name }}) Read(reader io.Reader) {{ type_name }} {
@@ -169,16 +196,32 @@ func (c {{ ffi_converter_name }}) Lower(value {{ type_name }}) C.uint64_t {
 	// because the handle will be decremented immediately after this function returns,
 	// and someone will be left holding onto a non-locked handle.
 	{%- if obj.has_callback_interface() %}
-	handle := C.uint64_t(c.handleMap.insert(value))
+	if val, ok := value.({{ impl_type_name }}); ok {
+		// Rust-backed object, clone the handle
+		handle := val.ffiObject.incrementPointer("{{ type_name }}")
+		defer val.ffiObject.decrementPointer()
+		return handle
+	} else {
+		// Go-backed object, insert into handle map
+		return C.uint64_t(c.handleMap.insert(value))
+	}
 	{%- else %}
 	handle := value.ffiObject.incrementPointer("{{ type_name }}")
 	defer value.ffiObject.decrementPointer()
-	{%- endif %}
 	return handle
+	{%- endif %}
 }
 
 func (c {{ ffi_converter_name }}) Write(writer io.Writer, value {{ type_name }}) {
 	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternal{{ canonical_type_name }}(handle uint64) {{ type_name }} {
+	return {{ ffi_converter_instance }}.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternal{{ canonical_type_name }}(value {{ type_name }}) uint64 {
+	return uint64({{ ffi_converter_instance }}.Lower(value))
 }
 
 type {{ obj|ffi_destroyer_name(ci) }} struct {}
@@ -187,8 +230,6 @@ func (_ {{ obj|ffi_destroyer_name(ci) }}) Destroy(value {{ type_name }}) {
 	{%- if obj.has_callback_interface() %}
 	if val, ok := value.({{ impl_type_name }}); ok {
 		val.Destroy()
-	} else {
-		panic("Expected {{ impl_type_name }}")
 	}
 	{%- else %}
 		value.Destroy()
@@ -203,4 +244,3 @@ func (_ {{ obj|ffi_destroyer_name(ci) }}) Destroy(value {{ type_name }}) {
 {%- include "VTableImpl.go" %}
 
 {%- endif %}
-

--- a/bindgen/templates/ObjectTemplate.go
+++ b/bindgen/templates/ObjectTemplate.go
@@ -97,6 +97,13 @@ func (_self {{ impl_type_name }}) Hash() uint64 {
 	{% call go::ffi_call_binding(hash, "_pointer") %}
 }
 
+{% when UniffiTrait::Ord { cmp } %}
+func (_self {{ impl_type_name }}) Cmp(other {{ type_name }}) int32 {
+	_pointer := _self.ffiObject.incrementPointer("{{ type_name }}")
+	defer _self.ffiObject.decrementPointer()
+	{% call go::ffi_call_binding(cmp, "_pointer") %}
+}
+
 {% endmatch %}
 {% endfor -%}
 

--- a/bindgen/templates/ObjectTemplate.go
+++ b/bindgen/templates/ObjectTemplate.go
@@ -144,15 +144,15 @@ func (_self {{impl_type_name}}) AsError() error {
 }
 {% endif -%}
 
-func (c {{ ffi_converter_name }}) Lift(pointer unsafe.Pointer) {{ type_name }} {
+func (c {{ ffi_converter_name }}) Lift(handle C.uint64_t) {{ type_name }} {
 	result := &{{ impl_name }} {
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.{{ obj.ffi_object_clone().name() }}(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.{{ obj.ffi_object_clone().name() }}(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.{{ obj.ffi_object_free().name() }}(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.{{ obj.ffi_object_free().name() }}(handle, status)
 			},
 		),
 	}
@@ -161,25 +161,24 @@ func (c {{ ffi_converter_name }}) Lift(pointer unsafe.Pointer) {{ type_name }} {
 }
 
 func (c {{ ffi_converter_name }}) Read(reader io.Reader) {{ type_name }} {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c {{ ffi_converter_name }}) Lower(value {{ type_name }}) unsafe.Pointer {
+func (c {{ ffi_converter_name }}) Lower(value {{ type_name }}) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
 	{%- if obj.has_callback_interface() %}
-	pointer := unsafe.Pointer(uintptr(c.handleMap.insert(value)))
+	handle := C.uint64_t(c.handleMap.insert(value))
 	{%- else %}
-	pointer := value.ffiObject.incrementPointer("{{ type_name }}")
+	handle := value.ffiObject.incrementPointer("{{ type_name }}")
 	defer value.ffiObject.decrementPointer()
 	{%- endif %}
-	return pointer
-	
+	return handle
 }
 
 func (c {{ ffi_converter_name }}) Write(writer io.Writer, value {{ type_name }}) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
 }
 
 type {{ obj|ffi_destroyer_name(ci) }} struct {}

--- a/bindgen/templates/RecordTemplate.go
+++ b/bindgen/templates/RecordTemplate.go
@@ -19,48 +19,9 @@ func (r *{{ type_name }}) Destroy() {
 }
 
 {%- let trait_methods = rec.uniffi_trait_methods() %}
-{%- if let Some(display_fmt) = trait_methods.display_fmt %}
-func (_self {{ type_name }}) String() string {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(display_fmt, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(debug_fmt) = trait_methods.debug_fmt %}
-func (_self {{ type_name }}) DebugString() string {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(debug_fmt, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(eq_eq) = trait_methods.eq_eq %}
-func (_self {{ type_name }}) Eq(other {{ type_name }}) bool {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(eq_eq, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(eq_ne) = trait_methods.eq_ne %}
-func (_self {{ type_name }}) Ne(other {{ type_name }}) bool {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(eq_ne, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(hash_hash) = trait_methods.hash_hash %}
-func (_self {{ type_name }}) Hash() uint64 {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(hash_hash, "_selfBuf") %}
-}
-
-{%- endif %}
-{%- if let Some(ord_cmp) = trait_methods.ord_cmp %}
-func (_self {{ type_name }}) Cmp(other {{ type_name }}) int8 {
-	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
-	{% call go::ffi_call_binding(ord_cmp, "_selfBuf") %}
-}
-
-{%- endif %}
+{%- let receiver_type = type_name %}
+{%- let self_binding = "_selfBuf" %}
+{%- include "TraitMethods.go" %}
 
 type {{ ffi_converter_name }} struct {}
 

--- a/bindgen/templates/RecordTemplate.go
+++ b/bindgen/templates/RecordTemplate.go
@@ -18,6 +18,50 @@ func (r *{{ type_name }}) Destroy() {
 	{%- endfor %}
 }
 
+{%- let trait_methods = rec.uniffi_trait_methods() %}
+{%- if let Some(display_fmt) = trait_methods.display_fmt %}
+func (_self {{ type_name }}) String() string {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(display_fmt, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(debug_fmt) = trait_methods.debug_fmt %}
+func (_self {{ type_name }}) DebugString() string {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(debug_fmt, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(eq_eq) = trait_methods.eq_eq %}
+func (_self {{ type_name }}) Eq(other {{ type_name }}) bool {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(eq_eq, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(eq_ne) = trait_methods.eq_ne %}
+func (_self {{ type_name }}) Ne(other {{ type_name }}) bool {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(eq_ne, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(hash_hash) = trait_methods.hash_hash %}
+func (_self {{ type_name }}) Hash() uint64 {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(hash_hash, "_selfBuf") %}
+}
+
+{%- endif %}
+{%- if let Some(ord_cmp) = trait_methods.ord_cmp %}
+func (_self {{ type_name }}) Cmp(other {{ type_name }}) int8 {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(ord_cmp, "_selfBuf") %}
+}
+
+{%- endif %}
+
 type {{ ffi_converter_name }} struct {}
 
 var {{ ffi_converter_instance }} = {{ ffi_converter_name }}{}

--- a/bindgen/templates/TraitMethods.go
+++ b/bindgen/templates/TraitMethods.go
@@ -1,0 +1,42 @@
+{%- if let Some(display_fmt) = trait_methods.display_fmt %}
+func (_self {{ receiver_type }}) String() string {
+	{{ self_binding }} := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(display_fmt, self_binding) %}
+}
+
+{%- endif %}
+{%- if let Some(debug_fmt) = trait_methods.debug_fmt %}
+func (_self {{ receiver_type }}) DebugString() string {
+	{{ self_binding }} := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(debug_fmt, self_binding) %}
+}
+
+{%- endif %}
+{%- if let Some(eq_eq) = trait_methods.eq_eq %}
+func (_self {{ receiver_type }}) Eq(other {{ receiver_type }}) bool {
+	{{ self_binding }} := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(eq_eq, self_binding) %}
+}
+
+{%- endif %}
+{%- if let Some(eq_ne) = trait_methods.eq_ne %}
+func (_self {{ receiver_type }}) Ne(other {{ receiver_type }}) bool {
+	{{ self_binding }} := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(eq_ne, self_binding) %}
+}
+
+{%- endif %}
+{%- if let Some(hash_hash) = trait_methods.hash_hash %}
+func (_self {{ receiver_type }}) Hash() uint64 {
+	{{ self_binding }} := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(hash_hash, self_binding) %}
+}
+
+{%- endif %}
+{%- if let Some(ord_cmp) = trait_methods.ord_cmp %}
+func (_self {{ receiver_type }}) Cmp(other {{ receiver_type }}) int8 {
+	{{ self_binding }} := {{ ffi_converter_instance }}.Lower(_self)
+	{% call go::ffi_call_binding(ord_cmp, self_binding) %}
+}
+
+{%- endif %}

--- a/bindgen/templates/VTableImpl.go
+++ b/bindgen/templates/VTableImpl.go
@@ -25,9 +25,9 @@ func {{ callback_name }}(
 	result := make(chan C.{{ result_struct }}, 1)
 	cancel := make(chan struct{}, 1)
 	guardHandle := cgo.NewHandle(cancel)
-	*uniffiOutReturn = C.UniffiForeignFuture {
+	*uniffiOutDroppedCallback = C.UniffiForeignFutureDroppedCallbackStruct {
 		handle: C.uint64_t(guardHandle),
-		free: C.UniffiForeignFutureFree(C.{{ config|free_gorutine_callback }}),
+		free: C.UniffiForeignFutureDroppedCallback(C.{{ config|free_gorutine_callback }}),
 	}
 	
 	// Wait for compleation or cancel
@@ -94,25 +94,36 @@ func {{ callback_name }}(
 
 {%- let free_callback = self::oracle().cgo_vtable_free_fn_name(name, module_path) %}
 {%- let free_type = "CallbackInterfaceFree"|ffi_callback_name %}
+{%- let clone_callback = self::oracle().cgo_vtable_clone_fn_name(name, module_path) %}
+{%- let clone_type = "CallbackInterfaceClone"|ffi_callback_name %}
 
 {%- let vtable_name = vtable|cgo_ffi_type -%}
 {%- let vtable_name = format!("{vtable_name}INSTANCE") -%}
 
 var {{ vtable_name }} = {{ vtable|ffi_type_name_cgo_safe }} {
+	uniffiFree: (C.{{ free_type }})(C.{{ free_callback }}),
+	uniffiClone: (C.{{ clone_type }})(C.{{ clone_callback }}),
 	{%- for (ffi_callback, meth) in vtable_methods.iter() %}
 	{% let callback_name = ffi_callback|cgo_callback_fn_name(module_path) -%}
 	{% let callback_type = ffi_callback.name()|ffi_callback_name -%}
-	
-	{{ meth.name()|var_name }}: (C.{{ callback_type }})(C.{{ callback_name }}),
-	
-	{%- endfor %}
 
-	uniffiFree: (C.{{ free_type }})(C.{{ free_callback }}),
+	{{ meth.name()|var_name }}: (C.{{ callback_type }})(C.{{ callback_name }}),
+
+	{%- endfor %}
 }
 
 //export {{ free_callback }}
 func {{ free_callback }}(handle C.uint64_t) {
 	{{ ffi_converter_instance }}.handleMap.remove(uint64(handle))
+}
+
+//export {{ clone_callback }}
+func {{ clone_callback }}(handle C.uint64_t) C.uint64_t {
+	val, ok := {{ ffi_converter_instance }}.handleMap.tryGet(uint64(handle))
+	if !ok {
+		panic(fmt.Errorf("no callback in handle map: %d", handle))
+	}
+	return C.uint64_t({{ ffi_converter_instance }}.handleMap.insert(val))
 }
 
 func (c {{ ffi_converter_name }}) register() {

--- a/bindgen/templates/VTableRuntime.go
+++ b/bindgen/templates/VTableRuntime.go
@@ -9,6 +9,7 @@ type concurrentHandleMap[T any] struct {
 func newConcurrentHandleMap[T any]() *concurrentHandleMap[T] {
 	return &concurrentHandleMap[T]{
 		handles:  map[uint64]T{},
+		currentHandle: 1,
 	}
 }
 
@@ -16,9 +17,10 @@ func (cm *concurrentHandleMap[T]) insert(obj T) uint64 {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
-	cm.currentHandle = cm.currentHandle + 1
-	cm.handles[cm.currentHandle] = obj
-	return cm.currentHandle
+	handle := cm.currentHandle
+	cm.currentHandle = cm.currentHandle + 2
+	cm.handles[handle] = obj
+	return handle
 }
 
 func (cm *concurrentHandleMap[T]) remove(handle uint64) {

--- a/bindgen/templates/macros.go
+++ b/bindgen/templates/macros.go
@@ -57,7 +57,7 @@
 {%- macro to_ffi_call(func, prefix) -%}
 	{%- match func.throws_type() %}
 	{%- when Some with (e) -%}
-	rustCallWithError[{{ e|canonical_name(ci) }}]({{ e|ffi_converter_name(ci) }}{},
+	rustCallWithError[{{ e|type_name(ci) }}]({{ e|ffi_converter_name(ci) }}{},
 	{%- else -%}
 	rustCall(
 	{%- endmatch %}
@@ -157,7 +157,7 @@
 	
     {%- match (func.return_type(), func.throws_type()) %}
     {%- when (Some(return_type), Some(e)) -%}
-	uniffiRustCallAsync[{{ e|canonical_name(ci) }}](
+	uniffiRustCallAsync[{{ e|type_name(ci) }}](
         {{ e|ffi_converter_instance(ci) }},
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) {{ return_type|ffi_type_name }} {
@@ -169,7 +169,7 @@
 			return {{ return_type|lift_fn(ci) }}(ffi)
 		},
     {%- when (None, Some(e)) -%}
-	uniffiRustCallAsync[{{ e|canonical_name(ci) }}](
+	uniffiRustCallAsync[{{ e|type_name(ci) }}](
         {{ e|ffi_converter_instance(ci) }},
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {

--- a/binding_tests/coverall_test.go
+++ b/binding_tests/coverall_test.go
@@ -379,7 +379,7 @@ func TestPath(t *testing.T) {
 		assert.Equal(uint64(2), traits[1].StrongCount())
 
 		traits[0].SetParent(&traits[1])
-		assert.Equal(uint64(2), traits[1].StrongCount())
+		assert.Equal(uint64(3), traits[1].StrongCount())
 		assert.ElementsMatch([]string{"node-2"}, coverall.AncestorNames(traits[0]))
 		assert.ElementsMatch([]string{}, coverall.AncestorNames(traits[1]))
 		assert.Equal("node-2", (*traits[0].GetParent()).Name())

--- a/binding_tests/ext_types_test.go
+++ b/binding_tests/ext_types_test.go
@@ -1,8 +1,3 @@
-//go:build ignore
-
-// TODO(pna): currently broken, ExternalTypes provide incorrect objects for
-// proc_macro defined traits
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/binding_tests/futures_test.go
+++ b/binding_tests/futures_test.go
@@ -152,6 +152,34 @@ func TestFuturesAsyncUdlTraitMethods(t *testing.T) {
 	assert.Equal(t, "Hello, Bob!", res2)
 }
 
+func TestFuturesRecordAndEnumTraits(t *testing.T) {
+	record1 := MakeTraitRecord("first", 1)
+	record2 := MakeTraitRecord("first", 1)
+	record3 := MakeTraitRecord("second", 2)
+
+	assert.Equal(t, "first:1", record1.String())
+	assert.Equal(t, "TraitRecord { label: \"first\", rank: 1 }", record1.DebugString())
+	assert.True(t, record1.Eq(record2))
+	assert.False(t, record1.Eq(record3))
+	assert.True(t, record1.Ne(record3))
+	assert.Equal(t, record1.Hash(), record2.Hash())
+	assert.Equal(t, int8(-1), record1.Cmp(record3))
+	assert.Equal(t, int8(0), record1.Cmp(record2))
+
+	enum1 := MakeTraitEnum(0)
+	enum2 := MakeTraitEnum(0)
+	enum3 := MakeTraitEnum(1)
+
+	assert.Equal(t, "alpha", enum1.String())
+	assert.Equal(t, "Alpha", enum1.DebugString())
+	assert.True(t, enum1.Eq(enum2))
+	assert.False(t, enum1.Eq(enum3))
+	assert.True(t, enum1.Ne(enum3))
+	assert.Equal(t, enum1.Hash(), enum2.Hash())
+	assert.Equal(t, int8(-1), enum1.Cmp(enum3))
+	assert.Equal(t, int8(0), enum1.Cmp(enum2))
+}
+
 type goAsyncParser struct {
 	completedDelays uint
 }
@@ -214,6 +242,16 @@ func TestFuturesForeignAsyncTraitMethods(t *testing.T) {
 	// Sleep a bit longer then a delay to confirm that task was acutaly cancled
 	time.Sleep(20)
 	assert.Equal(t, uint(2), traitObj.completedDelays)
+}
+
+func TestFuturesForeignTraitRecordRoundtrip(t *testing.T) {
+	traitObj := &goAsyncParser{}
+	holder := RoundtripParserHolder(ParserHolder{Parser: traitObj})
+
+	assert.Equal(t, "7", holder.Parser.AsString(0, 7))
+	holder.Destroy()
+
+	assert.Equal(t, uint(0), traitObj.completedDelays)
 }
 
 func TestFuturesAsyncObjectParam(t *testing.T) {

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -10,39 +10,39 @@ crate-type = ["cdylib", "staticlib", "lib"]
 
 [dependencies]
 # Examples
-uniffi-example-arithmetic = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-example-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-example-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-example-sprites = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-example-todolist = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-example-traits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-example-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
+uniffi-example-arithmetic = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-sprites = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-todolist = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-traits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
 
 # Fixtures
 # NOTE: taken from upstream, due to collision between new_megaphone and Megaphone interface constructor names
-# uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
+# uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
 uniffi-fixture-futures = { path = "./futures" }
 
 
-uniffi-fixture-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-docstring = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-enum-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-error-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-ext-types-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-ext-types-lib-one = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-ext-types-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-large-enum = { package = "large-enum", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-large-error = { package = "large-error", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-simple-fns = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-simple-iface = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-trait-methods = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
-uniffi-fixture-type-limits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.29.5"}
+uniffi-fixture-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-docstring = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-enum-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-error-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-ext-types-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-ext-types-lib-one = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-ext-types-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-large-enum = { package = "large-enum", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-large-error = { package = "large-error", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-simple-fns = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-simple-iface = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-trait-methods = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-type-limits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
 
 # Go specific
 uniffi-go-fixture-destroy = { path = "destroy" }

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::{
+    fmt,
     future::Future,
     pin::Pin,
     sync::{Arc, Mutex, MutexGuard},
@@ -345,6 +346,59 @@ pub struct SharedResourceOptions {
     pub timeout_ms: u16,
 }
 
+#[derive(uniffi::Record, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[uniffi::export(Display, Debug, Eq, Hash, Ord)]
+pub struct TraitRecord {
+    pub label: String,
+    pub rank: u8,
+}
+
+impl fmt::Display for TraitRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.label, self.rank)
+    }
+}
+
+#[derive(uniffi::Enum, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+#[uniffi::export(Display, Debug, Eq, Hash, Ord)]
+pub enum TraitEnum {
+    Alpha,
+    Beta,
+}
+
+impl fmt::Display for TraitEnum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Alpha => write!(f, "alpha"),
+            Self::Beta => write!(f, "beta"),
+        }
+    }
+}
+
+#[derive(uniffi::Record)]
+pub struct ParserHolder {
+    pub parser: Arc<dyn AsyncParser>,
+}
+
+#[uniffi::export]
+fn make_trait_record(label: String, rank: u8) -> TraitRecord {
+    TraitRecord { label, rank }
+}
+
+#[uniffi::export]
+fn make_trait_enum(rank: u8) -> TraitEnum {
+    if rank == 0 {
+        TraitEnum::Alpha
+    } else {
+        TraitEnum::Beta
+    }
+}
+
+#[uniffi::export]
+fn roundtrip_parser_holder(holder: ParserHolder) -> ParserHolder {
+    holder
+}
+
 // Our error.
 #[derive(thiserror::Error, uniffi::Error, Debug)]
 pub enum AsyncError {
@@ -384,6 +438,7 @@ pub trait SayAfterTrait: Send + Sync {
 }
 
 // Example of async trait defined in the UDL file
+#[uniffi::trait_interface]
 #[async_trait::async_trait]
 pub trait SayAfterUdlTrait: Send + Sync {
     async fn say_after(&self, ms: u16, who: String) -> String;


### PR DESCRIPTION
Following the upgrade to v0.29, we here attempt the upgrade to v0.30.

Draft for now, but tests/fixtures pass locally.