### PR TITLE
Upgrade to `uniffi` v0.31

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.85
+      image: rust:1.87
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.7.0+v0.31.0
+- **BREAKING** Upgrade to `uniffi-rs` v0.31.0
+- **BREAKING** Bump MSRV to 1.87
+
 ### v0.6.0+v0.30.0
 - **BREAKING** Upgrade to `uniffi-rs` v0.30.0
 - Update object handles to match `uniffi`'s `uint64` FFI representation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### v0.7.0+v0.31.0
 - **BREAKING** Upgrade to `uniffi-rs` v0.31.0
 - **BREAKING** Bump MSRV to 1.87
+- Adapt binding loading to UniFFI's `BindgenLoader` / `BindgenPaths` APIs
+- Normalize callback symbol names for full `module_path` values in UniFFI 0.31
+- Add generated methods for records and enums
 
 ### v0.6.0+v0.30.0
 - **BREAKING** Upgrade to `uniffi-rs` v0.30.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,6 @@ dependencies = [
  "anyhow",
  "askama 0.13.1",
  "camino",
- "cargo_metadata",
  "clap",
  "extend",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -19,15 +19,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "askama"
@@ -64,7 +64,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
 dependencies = [
- "askama_derive",
+ "askama_derive 0.13.1",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive 0.14.0",
  "itoa",
  "percent-encoding",
  "serde",
@@ -77,7 +90,24 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
 dependencies = [
- "askama_parser",
+ "askama_parser 0.13.0",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser 0.14.0",
  "basic-toml",
  "memchr",
  "proc-macro2",
@@ -97,7 +127,19 @@ dependencies = [
  "memchr",
  "serde",
  "serde_derive",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -138,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -260,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blocking"
@@ -279,15 +321,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"
@@ -318,7 +360,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -329,18 +371,18 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -348,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -360,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -372,15 +414,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "concurrent-queue"
@@ -519,6 +561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -553,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -563,15 +611,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -580,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -599,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -610,21 +658,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -634,20 +682,20 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -677,6 +725,15 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -779,6 +836,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,7 +869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -825,9 +888,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -845,19 +908,19 @@ dependencies = [
 [[package]]
 name = "large-enum"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "large-error"
 version = "0.26.1"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
@@ -867,16 +930,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -895,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minimal-lexical"
@@ -926,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -956,9 +1025,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -968,9 +1037,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -1007,28 +1076,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.105"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rustc-hash"
@@ -1038,9 +1117,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1139,15 +1218,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1181,9 +1260,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1203,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -1236,11 +1315,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1256,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1277,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "pin-project-lite",
 ]
@@ -1296,7 +1375,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1310,24 +1389,24 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1342,42 +1421,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "uniffi"
-version = "0.30.0"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c866f627c3f04c3df068b68bb2d725492caaa539dd313e2a9d26bb85b1a32f4e"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uniffi"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
 dependencies = [
  "anyhow",
  "camino",
  "cargo_metadata",
  "clap",
- "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_core 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_core 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi"
-version = "0.30.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "uniffi_bindgen 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
- "uniffi_build 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
- "uniffi_core 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
- "uniffi_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
- "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_bindgen 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_build 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_core 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_macros 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_pipeline 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-bindgen-go"
-version = "0.6.0+v0.30.0"
+version = "0.7.0+v0.31.0"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.13.1",
  "camino",
  "cargo_metadata",
  "clap",
@@ -1389,9 +1474,9 @@ dependencies = [
  "serde_json",
  "textwrap",
  "toml",
- "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_udl 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1437,140 +1522,140 @@ dependencies = [
 [[package]]
 name = "uniffi-example-arithmetic"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-example-callbacks"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-example-custom-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
  "url",
 ]
 
 [[package]]
 name = "uniffi-example-futures"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "async-std",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-example-geometry"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-example-rondpoint"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-example-sprites"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-example-todolist"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "once_cell",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-example-traits"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-callbacks"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-coverall"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "once_cell",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-docstring"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-enum-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-error-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-ext-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-external-crate",
@@ -1582,38 +1667,38 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-ext-types-custom-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "bytes",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-ext-types-external-crate"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 
 [[package]]
 name = "uniffi-fixture-ext-types-lib-one"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "bytes",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-ext-types-proc-macro"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-lib-one",
@@ -1623,10 +1708,10 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-ext-types-sub-lib"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
  "uniffi-fixture-ext-types-lib-one",
 ]
 
@@ -1639,63 +1724,63 @@ dependencies = [
  "once_cell",
  "thiserror 1.0.69",
  "tokio",
- "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-fixture-proc-macro"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "lazy_static",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-simple-fns"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-simple-iface"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "lazy_static",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-time"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "chrono",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-trait-methods"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "once_cell",
- "thiserror 2.0.17",
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "thiserror 2.0.18",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-type-limits"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
- "uniffi 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
@@ -1704,18 +1789,18 @@ version = "1.0.0"
 dependencies = [
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-go-fixture-empty-string-and-bytes"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1723,28 +1808,28 @@ name = "uniffi-go-fixture-errors"
 version = "1.0.0"
 dependencies = [
  "thiserror 1.0.69",
- "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-go-fixture-issue43"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi-go-fixture-issue45",
- "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-go-fixture-issue45"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1753,8 +1838,8 @@ version = "0.22.0"
 dependencies = [
  "glob",
  "thiserror 1.0.69",
- "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_testing",
 ]
 
@@ -1765,19 +1850,19 @@ dependencies = [
  "crossbeam",
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8ca600167641ebe7c8ba9254af40492dda3397c528cc3b2f511bd23e8541a5"
+checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.14.0",
  "camino",
  "cargo_metadata",
  "fs-err",
@@ -1790,20 +1875,20 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml",
- "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_testing",
- "uniffi_udl 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.30.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
- "askama",
+ "askama 0.14.0",
  "camino",
  "cargo_metadata",
  "fs-err",
@@ -1816,38 +1901,38 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml",
- "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
- "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
- "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
- "uniffi_udl 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_internal_macros 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_meta 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_pipeline 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_udl 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e55c05228f4858bb258f651d21d743fcc1fe5a2ec20d3c0f9daefddb105ee4d"
+checksum = "b78fd9271a4c2e85bd2c266c5a9ede1fac676eb39fd77f636c27eaf67426fd5f"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.30.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_bindgen 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi_core"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7a5a038ebffe8f4cf91416b154ef3c2468b18e828b7009e01b1b99938089f9"
+checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1858,8 +1943,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.30.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1869,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c2a6f93e7b73726e2015696ece25ca0ac5a5f1cf8d6a7ab5214dd0a01d2edf"
+checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1882,8 +1967,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.30.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1894,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c6309fc36c7992afc03bc0c5b059c656bccbef3f2a4bc362980017f8936141"
+checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
 dependencies = [
  "camino",
  "fs-err",
@@ -1906,13 +1991,13 @@ dependencies = [
  "serde",
  "syn",
  "toml",
- "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.30.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "camino",
  "fs-err",
@@ -1922,62 +2007,62 @@ dependencies = [
  "serde",
  "syn",
  "toml",
- "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_meta 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a138823392dba19b0aa494872689f97d0ee157de5852e2bec157ce6de9cdc22"
+checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
 dependencies = [
  "anyhow",
  "siphasher",
- "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.30.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "siphasher",
- "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
- "uniffi_pipeline 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_internal_macros 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_pipeline 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c27c4b515d25f8e53cc918e238c39a79c3144a40eaf2e51c4a7958973422c29"
+checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap",
  "tempfile",
- "uniffi_internal_macros 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.30.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap",
  "tempfile",
- "uniffi_internal_macros 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_internal_macros 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
 name = "uniffi_testing"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4adb08eb5589849231dc0626ba0f9a1297925fd751f0740fc630ae934dd9c5e"
+checksum = "4802bed208a296657eef3451a961a6502e1d7aa8930b4b0cd952ed4f81a3957e"
 dependencies = [
  "anyhow",
  "camino",
@@ -1988,25 +2073,25 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0adacdd848aeed7af4f5af7d2f621d5e82531325d405e29463482becfdeafca"
+checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle2 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.30.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta 0.30.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
- "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0)",
+ "uniffi_meta 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
 ]
 
 [[package]]
@@ -2041,18 +2126,27 @@ checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2063,11 +2157,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -2076,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2086,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2099,18 +2194,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.83"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2128,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.30.0#47cb43774d7d4dc2fb13225fb95fb1eb24efa893"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
 dependencies = [
  "nom",
 ]
@@ -2150,18 +2279,106 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.46.0"
+name = "winnow"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -2248,6 +2465,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-rust-version = "1.85"
+rust-version = "1.87"
 members = [
     "bindgen",
     "fixtures",
@@ -12,10 +12,10 @@ members = [
 ]
 
 [workspace.dependencies]
-uniffi = "0.30.0"
-uniffi_testing = "0.30.0"
-uniffi_macros = "0.30.0"
-uniffi_build = { version = "0.30.0", features=["builtin-bindgen"] }
-uniffi_bindgen = "0.30.0"
-uniffi_meta = "0.30.0"
-uniffi_udl = "0.30.0"
+uniffi = "0.31.0"
+uniffi_testing = "0.31.0"
+uniffi_macros = "0.31.0"
+uniffi_build = { version = "0.31.0", features=["builtin-bindgen"] }
+uniffi_bindgen = "0.31.0"
+uniffi_meta = "0.31.0"
+uniffi_udl = "0.31.0"

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 Generate [UniFFI](https://github.com/mozilla/uniffi-rs) bindings for Go. `uniffi-bindgen-go` lives
 as a separate project from `uniffi-go`, as per
 [uniffi-rs #1355](https://github.com/mozilla/uniffi-rs/issues/1355). Currently, `uniffi-bindgen-go`
-uses `uniffi-rs` version `0.30.0`.
+uses `uniffi-rs` version `0.31.0`.
 
 # How to install
 
-Minimum Rust version required to install `uniffi-bindgen-go` is `1.85`.
+Minimum Rust version required to install `uniffi-bindgen-go` is `1.87`.
 Newer Rust versions should also work fine.
 
 ```
-cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.6.0+v0.30.0
+cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.7.0+v0.31.0
 ```
 
 # How to generate bindings
@@ -67,6 +67,7 @@ The table shows the `uniffi-rs` version targeted by each published `uniffi-bindg
 
 | uniffi-bindgen-go version                | uniffi-rs version                                |
 |------------------------------------------|--------------------------------------------------|
+| v0.7.0                                   | v0.31.0                                          |
 | v0.6.0                                   | v0.30.0                                          |
 | v0.5.0                                   | v0.29.5                                          |
 | v0.4.0                                   | v0.28.3                                          |

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -17,7 +17,6 @@ askama = { version = "0.13", default-features = false, features = ["config", "de
 clap = { version = "4", features = ["cargo", "std", "derive"] }
 extend = "1.1"
 heck = "0.5"
-cargo_metadata = "0.19"
 serde = "1"
 toml = "0.9"
 camino = "1.0.8"

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-go"
-version = "0.6.0+v0.30.0"
+version = "0.7.0+v0.31.0"
 edition = "2021"
 
 [lib]

--- a/bindgen/src/gen_go/filters.rs
+++ b/bindgen/src/gen_go/filters.rs
@@ -163,6 +163,14 @@ pub fn cgo_callback_fn_name(
     Ok(oracle().cgo_callback_fn_name(f, module_path))
 }
 
+pub fn module_path(type_: &impl AsType) -> Result<String, askama::Error> {
+    Ok(match type_.as_type() {
+        Type::CallbackInterface { module_path, .. } => module_path,
+        Type::Object { module_path, .. } => module_path,
+        _ => unreachable!(),
+    })
+}
+
 /// FFI type name to be used to reference cgo types
 pub fn ffi_type_name<T: Clone + Into<FfiType>>(type_: &T) -> Result<String, askama::Error> {
     let ffi_type: FfiType = type_.clone().into();

--- a/bindgen/src/gen_go/mod.rs
+++ b/bindgen/src/gen_go/mod.rs
@@ -333,6 +333,23 @@ fn module_path(type_: &impl AsType) -> String {
 pub struct GoCodeOracle;
 
 impl GoCodeOracle {
+    fn sanitize_symbol_component(&self, value: &str) -> String {
+        let mut out = String::with_capacity(value.len());
+        let mut prev_was_underscore = false;
+
+        for ch in value.chars() {
+            if ch.is_ascii_alphanumeric() {
+                out.push(ch);
+                prev_was_underscore = false;
+            } else if !prev_was_underscore {
+                out.push('_');
+                prev_was_underscore = true;
+            }
+        }
+
+        out.trim_matches('_').to_string()
+    }
+
     // Map `Type` instances to a `Box<dyn CodeType>` for that type.
     //
     // There is a companion match in `templates/Types.go` which performs a similar function for the
@@ -507,16 +524,19 @@ impl GoCodeOracle {
 
     /// Get cgo symbol name for a callback function
     fn cgo_callback_fn_name(&self, f: &FfiCallbackFunction, module_path: &str) -> String {
+        let module_path = self.sanitize_symbol_component(module_path);
         format!("{module_path}_cgo_dispatch{}", f.name())
     }
 
     /// Get cgo symbol name for a vtable free function
     fn cgo_vtable_free_fn_name(&self, nm: &str, module_path: &str) -> String {
+        let module_path = self.sanitize_symbol_component(module_path);
         format!("{module_path}_cgo_dispatchCallbackInterface{nm}Free")
     }
 
     /// Get cgo symbol name for a vtable clone function
     fn cgo_vtable_clone_fn_name(&self, nm: &str, module_path: &str) -> String {
+        let module_path = self.sanitize_symbol_component(module_path);
         format!("{module_path}_cgo_dispatchCallbackInterface{nm}Clone")
     }
 

--- a/bindgen/src/lib.rs
+++ b/bindgen/src/lib.rs
@@ -11,7 +11,7 @@ use fs_err::{self as fs};
 use gen_go::generate_go_bindings;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
-use uniffi_bindgen::{Component, GenerationSettings};
+use uniffi_bindgen::{BindgenLoader, BindgenPaths, Component, GenerationSettings};
 
 #[derive(Parser)]
 #[clap(name = "uniffi-bindgen")]
@@ -32,21 +32,17 @@ struct Cli {
     #[clap(long, short)]
     config: Option<Utf8PathBuf>,
 
-    /// Extract proc-macro metadata from a native lib (cdylib or staticlib) for this crate.
-    #[clap(long, short)]
-    lib_file: Option<Utf8PathBuf>,
-
-    /// Pass in a cdylib path rather than a UDL file
+    /// Compatibility flag for older invocations.
+    ///
+    /// UniFFI v0.31.0 auto-detects whether `source` is a UDL file or a library.
     #[clap(long = "library")]
     library_mode: bool,
 
-    /// When `--library` is passed, only generate bindings for one crate.
-    /// When `--library` is not passed, use this as the crate name instead of attempting to
-    /// locate and parse Cargo.toml.
+    /// Filter generated bindings to a single crate.
     #[clap(long = "crate")]
     crate_name: Option<String>,
 
-    /// Path to the UDL file, or cdylib if `library-mode` is specified
+    /// Path to the UDL file or compiled Rust library.
     source: Utf8PathBuf,
 }
 
@@ -143,48 +139,53 @@ pub fn main() -> anyhow::Result<()> {
         out_dir,
         no_format,
         config,
-        lib_file,
-        library_mode,
+        library_mode: _,
         crate_name,
         source,
     } = Cli::parse();
 
-    let config_supplier = {
-        use uniffi_bindgen::cargo_metadata::CrateConfigSupplier;
-        let cmd = ::cargo_metadata::MetadataCommand::new();
-        let metadata = cmd.exec().context("error running cargo metadata").unwrap();
-        CrateConfigSupplier::from(metadata)
-    };
+    let mut bindgen_paths = BindgenPaths::default();
+    if let Some(config_path) = &config {
+        bindgen_paths.add_config_override_layer(config_path.clone());
+    }
+    bindgen_paths.add_cargo_metadata_layer(false)?;
+
+    let loader = BindgenLoader::new(bindgen_paths);
     let binding_gen = BindingGeneratorGo;
 
-    if library_mode {
-        if lib_file.is_some() {
-            panic!("--lib-file is not compatible with --library.")
-        }
-        let out_dir = out_dir.expect("--out-dir is required when using --library");
-        let library_path = source;
+    let metadata = loader.load_metadata(&source)?;
+    let cis = loader.load_cis(metadata)?;
+    let cdylib = loader.library_name(&source).map(|name| name.to_string());
+    let mut components = loader.load_components(cis, |_ci, root_toml| {
+        uniffi_bindgen::BindingGenerator::new_config(&binding_gen, &root_toml)
+    })?;
 
-        uniffi_bindgen::library_mode::generate_bindings(
-            &library_path,
-            crate_name,
-            &binding_gen,
-            &config_supplier,
-            config.as_deref(),
-            &out_dir,
-            !no_format,
-        )?;
-    } else {
-        let udl_file = source;
-        uniffi_bindgen::generate_external_bindings(
-            &binding_gen,
-            udl_file,
-            config,
-            out_dir,
-            lib_file,
-            crate_name.as_deref(),
-            !no_format,
-        )?;
+    let settings = GenerationSettings {
+        out_dir: out_dir.unwrap_or_else(|| {
+            source
+                .parent()
+                .expect("source should have a parent directory")
+                .to_path_buf()
+        }),
+        try_format_code: !no_format,
+        cdylib,
+    };
+
+    uniffi_bindgen::BindingGenerator::update_component_configs(
+        &binding_gen,
+        &settings,
+        &mut components,
+    )?;
+
+    for component in &mut components {
+        component.ci.derive_ffi_funcs()?;
     }
+
+    if let Some(crate_name) = &crate_name {
+        components.retain(|component| component.ci.crate_name() == crate_name);
+    }
+
+    uniffi_bindgen::BindingGenerator::write_bindings(&binding_gen, &settings, &components)?;
 
     Ok(())
 }

--- a/bindgen/templates/CallbackInterfaceTemplate.go
+++ b/bindgen/templates/CallbackInterfaceTemplate.go
@@ -54,5 +54,6 @@ func ({{ ffi_destroyer_name }}) Destroy(value {{ type_name }}) {}
 {% let vtable = cbi.vtable() %}
 {%- let vtable_methods = cbi.vtable_methods() %}
 {%- let ffi_init_callback = cbi.ffi_init_callback() %}
+{%- let module_path = cbi|module_path %}
 
 {%- include "VTableImpl.go" %}

--- a/bindgen/templates/EnumTemplate.go
+++ b/bindgen/templates/EnumTemplate.go
@@ -31,6 +31,9 @@ const (
 {%- call go::docstring(e, 0) %}
 type {{ type_name }} interface {
 	Destroy()
+	{%- for meth in e.methods() %}
+	{{ meth.name()|fn_name }}({%- call go::arg_list_decl(meth) -%}) {% call go::return_type_decl(meth) %}
+	{%- endfor %}
 }
 
 {%- for variant in e.variants() %}
@@ -55,6 +58,36 @@ func (e {{ type_name }}{{ variant.name()|class_name }}) Destroy() {
 {%- let receiver_type = type_name %}
 {%- let self_binding = "_selfBuf" %}
 {%- include "TraitMethods.go" %}
+{%- endif %}
+
+{%- if e.is_flat() %}
+{%- for meth in e.methods() %}
+{%- call go::docstring(meth, 0) %}
+func (_self {{ type_name }}) {{ meth.name()|fn_name }}({%- call go::arg_list_decl(meth) -%}) {% call go::return_type_decl(meth) %} {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% if meth.is_async() %}
+	{% call go::async_ffi_call_binding(meth, "_selfBuf") %}
+	{% else %}
+	{% call go::ffi_call_binding(meth, "_selfBuf") %}
+	{% endif %}
+}
+
+{%- endfor %}
+{%- else %}
+{%- for variant in e.variants() %}
+{%- for meth in e.methods() %}
+{%- call go::docstring(meth, 0) %}
+func (_self {{ type_name }}{{ variant.name()|class_name }}) {{ meth.name()|fn_name }}({%- call go::arg_list_decl(meth) -%}) {% call go::return_type_decl(meth) %} {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% if meth.is_async() %}
+	{% call go::async_ffi_call_binding(meth, "_selfBuf") %}
+	{% else %}
+	{% call go::ffi_call_binding(meth, "_selfBuf") %}
+	{% endif %}
+}
+
+{%- endfor %}
+{%- endfor %}
 {%- endif %}
 
 type {{ ffi_converter_name }} struct {}

--- a/bindgen/templates/ObjectTemplate.go
+++ b/bindgen/templates/ObjectTemplate.go
@@ -240,6 +240,7 @@ func (_ {{ obj|ffi_destroyer_name(ci) }}) Destroy(value {{ type_name }}) {
 {%- let vtable = obj.vtable().expect("trait interface should have a vtable") %}
 {%- let vtable_methods = obj.vtable_methods() %}
 {%- let ffi_init_callback = obj.ffi_init_callback() %}
+{%- let module_path = obj|module_path %}
 
 {%- include "VTableImpl.go" %}
 

--- a/bindgen/templates/RecordTemplate.go
+++ b/bindgen/templates/RecordTemplate.go
@@ -23,6 +23,19 @@ func (r *{{ type_name }}) Destroy() {
 {%- let self_binding = "_selfBuf" %}
 {%- include "TraitMethods.go" %}
 
+{%- for meth in rec.methods() %}
+{%- call go::docstring(meth, 0) %}
+func (_self {{ type_name }}) {{ meth.name()|fn_name }}({%- call go::arg_list_decl(meth) -%}) {% call go::return_type_decl(meth) %} {
+	_selfBuf := {{ ffi_converter_instance }}.Lower(_self)
+	{% if meth.is_async() %}
+	{% call go::async_ffi_call_binding(meth, "_selfBuf") %}
+	{% else %}
+	{% call go::ffi_call_binding(meth, "_selfBuf") %}
+	{% endif %}
+}
+
+{%- endfor %}
+
 type {{ ffi_converter_name }} struct {}
 
 var {{ ffi_converter_instance }} = {{ ffi_converter_name }}{}

--- a/binding_tests/futures_test.go
+++ b/binding_tests/futures_test.go
@@ -178,6 +178,12 @@ func TestFuturesRecordAndEnumTraits(t *testing.T) {
 	assert.Equal(t, enum1.Hash(), enum2.Hash())
 	assert.Equal(t, int8(-1), enum1.Cmp(enum3))
 	assert.Equal(t, int8(0), enum1.Cmp(enum2))
+	assert.Equal(t, TraitRecord{Label: "first-bonus", Rank: 1}, record1.Relabel("bonus"))
+	assert.Equal(t, uint8(6), record1.Score(5))
+	assert.Equal(t, TraitEnumBeta, enum1.Flipped())
+	assert.Equal(t, TraitEnumAlpha, enum3.Flipped())
+	assert.Equal(t, "alpha", enum1.Label())
+	assert.Equal(t, "beta", enum3.Label())
 }
 
 type goAsyncParser struct {

--- a/binding_tests/proc_macro_test.go
+++ b/binding_tests/proc_macro_test.go
@@ -78,6 +78,10 @@ func TestProcMacro(t *testing.T) {
 
 	assert.Equal(t, uint8(ReprU8One), uint8(1))
 	assert.Equal(t, uint8(ReprU8Three), uint8(3))
+	assert.Equal(t, MaybeBoolFalse, MaybeBoolTrue.Next())
+	assert.Equal(t, MaybeBoolUncertain, MaybeBoolFalse.Next())
+	assert.False(t, MixedEnumNone{}.IsNotNone())
+	assert.True(t, MixedEnumInt{Field0: 99}.IsNotNone())
 
 	assert.Equal(t, GetMixedEnum(nil), MixedEnumInt{Field0: 1})
 	var me MixedEnum = MixedEnumNone{}

--- a/build_bindings.sh
+++ b/build_bindings.sh
@@ -18,4 +18,4 @@ LIB_FILE="$BINARIES_DIR/libuniffi_fixtures.dylib"
 else 
 LIB_FILE="$BINARIES_DIR/libuniffi_fixtures.so"
 fi
-target/debug/uniffi-bindgen-go $LIB_FILE --out-dir "$BINDINGS_DIR" --library --config "$ROOT_DIR/fixtures/uniffi.toml"
+target/debug/uniffi-bindgen-go "$LIB_FILE" --out-dir "$BINDINGS_DIR" --config "$ROOT_DIR/fixtures/uniffi.toml"

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -10,39 +10,39 @@ crate-type = ["cdylib", "staticlib", "lib"]
 
 [dependencies]
 # Examples
-uniffi-example-arithmetic = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-example-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-example-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-example-sprites = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-example-todolist = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-example-traits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-example-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-example-arithmetic = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-example-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-example-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-example-sprites = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-example-todolist = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-example-traits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-example-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
 
 # Fixtures
 # NOTE: taken from upstream, due to collision between new_megaphone and Megaphone interface constructor names
-# uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+# uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
 uniffi-fixture-futures = { path = "./futures" }
 
 
-uniffi-fixture-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-docstring = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-enum-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-error-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-ext-types-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-ext-types-lib-one = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-ext-types-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-large-enum = { package = "large-enum", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-large-error = { package = "large-error", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-simple-fns = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-simple-iface = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-trait-methods = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
-uniffi-fixture-type-limits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.30.0"}
+uniffi-fixture-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-docstring = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-enum-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-error-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-ext-types-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-ext-types-lib-one = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-ext-types-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-large-enum = { package = "large-enum", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-large-error = { package = "large-error", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-simple-fns = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-simple-iface = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-trait-methods = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-type-limits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
 
 # Go specific
 uniffi-go-fixture-destroy = { path = "destroy" }

--- a/fixtures/futures/src/lib.rs
+++ b/fixtures/futures/src/lib.rs
@@ -353,6 +353,20 @@ pub struct TraitRecord {
     pub rank: u8,
 }
 
+#[uniffi::export]
+impl TraitRecord {
+    fn relabel(&self, suffix: String) -> Self {
+        Self {
+            label: format!("{}-{}", self.label, suffix),
+            rank: self.rank,
+        }
+    }
+
+    fn score(&self, bonus: u8) -> u8 {
+        self.rank + bonus
+    }
+}
+
 impl fmt::Display for TraitRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.label, self.rank)
@@ -364,6 +378,23 @@ impl fmt::Display for TraitRecord {
 pub enum TraitEnum {
     Alpha,
     Beta,
+}
+
+#[uniffi::export]
+impl TraitEnum {
+    fn flipped(&self) -> Self {
+        match self {
+            Self::Alpha => Self::Beta,
+            Self::Beta => Self::Alpha,
+        }
+    }
+
+    fn label(&self) -> String {
+        match self {
+            Self::Alpha => "alpha".to_string(),
+            Self::Beta => "beta".to_string(),
+        }
+    }
 }
 
 impl fmt::Display for TraitEnum {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85"
+channel = "1.87"


### PR DESCRIPTION
Following the upgrade to v0.30, we here attempt the upgrade to v0.31.

