### PR TITLE
Fix async error propagation for RustBuffer-backed Go returns

### DIFF
--- a/bindgen/templates/Async.go
+++ b/bindgen/templates/Async.go
@@ -43,9 +43,13 @@ func uniffiRustCallAsync[E any, T any, F any](
 		pollResult = <-waiter
 	}
 
+	var goValue T
 	ffiValue, err := rustCallWithError(errConverter, func(status *C.RustCallStatus) F {
 		return completeFunc(rustFuture, status)
 	})
+	if value := reflect.ValueOf(err); value.IsValid() && !value.IsZero() {
+		return goValue, err
+	}
 	return liftFunc(ffiValue), err
 }
 

--- a/bindgen/templates/wrapper.go
+++ b/bindgen/templates/wrapper.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 	"encoding/binary"
 	{%- if ci.has_async_fns() %}
+	"reflect"
 	"runtime/cgo"
 	{%- endif %}
 	{%- for imported_package in self.imports() %}

--- a/binding_tests/objects_test.go
+++ b/binding_tests/objects_test.go
@@ -181,3 +181,13 @@ func TestAsyncFailureProperlyCleansFuture(t *testing.T) {
 
 	assert.EqualError(t, err, "ObjectError: InvalidOperation: InvalidOperation")
 }
+
+func TestAsyncFailureReturningRustBufferPropagatesError(t *testing.T) {
+	result, err := objects.FallibleStringAsync(true)
+	assert.Equal(t, "", result)
+	assert.EqualError(t, err, "ObjectError: InvalidOperation: InvalidOperation")
+
+	result, err = objects.FallibleStringAsync(false)
+	assert.NoError(t, err)
+	assert.Equal(t, "all-good", result)
+}

--- a/fixtures/objects/src/lib.rs
+++ b/fixtures/objects/src/lib.rs
@@ -36,6 +36,16 @@ pub async fn fallible_object0_async(do_fail: bool) -> Result<Arc<Object0>, Objec
     }
 }
 
+// An async function returning a RustBuffer-backed value that can throw.
+#[uniffi::export]
+pub async fn fallible_string_async(do_fail: bool) -> Result<String, ObjectError> {
+    if do_fail {
+        Err(ObjectError::InvalidOperation)
+    } else {
+        Ok("all-good".to_string())
+    }
+}
+
 pub struct Object1 {
     message: String,
 }


### PR DESCRIPTION
## Summary

Generated Go async bindings currently try to `lift` the FFI return value even when the Rust future completed with an error.

That works for some handle-like return types, but it breaks for RustBuffer-backed values like `String` and `bytes`: on the error path the generated code attempts to decode a zero FFI value and surfaces an `EOF`-style failure instead of the original UniFFI error.

This PR fixes that by making `uniffiRustCallAsync` return the zero Go value immediately when `rustCallWithError` reports an error, before calling `liftFunc`.

The helper uses a reflection-based nil check because the generic error type can be a typed nil pointer, so a plain `err != nil` check is not reliable.

## Changes

- short-circuit async result lifting on error in the Go template
- add the required import for the generic typed-nil check
- add an `objects` fixture with an async fallible `String` return
- add a regression test covering both the error and success paths

## Testing

- `RUSTUP_TOOLCHAIN=stable ./build.sh`
- `RUSTUP_TOOLCHAIN=stable ./build_bindings.sh`
- `go test -v -run TestAsyncFailureReturningRustBufferPropagatesError` in `binding_tests`
- `go test -v` in `binding_tests`
