### PR TITLE
Fix panic when passing empty string with dangling `data` pointer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,7 @@ dependencies = [
  "uniffi-go-fixture-errors",
  "uniffi-go-fixture-issue43",
  "uniffi-go-fixture-issue45",
+ "uniffi-go-fixture-issue83",
  "uniffi-go-fixture-name-case",
  "uniffi-go-fixture-objects",
 ]
@@ -1824,6 +1825,15 @@ dependencies = [
 
 [[package]]
 name = "uniffi-go-fixture-issue45"
+version = "1.0.0"
+dependencies = [
+ "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uniffi-go-fixture-issue83"
 version = "1.0.0"
 dependencies = [
  "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bindgen/templates/BridgingHeaderTemplate.h
+++ b/bindgen/templates/BridgingHeaderTemplate.h
@@ -15,20 +15,20 @@
 // We ensure they are declared exactly once, with a header guard, UNIFFI_SHARED_H.
 #ifdef UNIFFI_SHARED_H
 	// We also try to prevent mixing versions of shared uniffi header structs.
-	// If you add anything to the #else block, you must increment the version suffix in UNIFFI_SHARED_HEADER_V6
-	#ifndef UNIFFI_SHARED_HEADER_V6
+	// If you add anything to the #else block, you must increment the version suffix in UNIFFI_SHARED_HEADER_V7
+	#ifndef UNIFFI_SHARED_HEADER_V7
 		#error Combining helper code from multiple versions of uniffi is not supported
-	#endif // ndef UNIFFI_SHARED_HEADER_V6
+	#endif // ndef UNIFFI_SHARED_HEADER_V7
 #else
 #define UNIFFI_SHARED_H
-#define UNIFFI_SHARED_HEADER_V6
+#define UNIFFI_SHARED_HEADER_V7
 // ⚠️ Attention: If you change this #else block (ending in `#endif // def UNIFFI_SHARED_H`) you *must* ⚠️
-// ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V6 in this file.           ⚠️
+// ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V7 in this file.           ⚠️
 
 typedef struct RustBuffer {
 	uint64_t capacity;
 	uint64_t len;
-	uint8_t *data;
+	uintptr_t data;
 } RustBuffer;
 
 typedef struct ForeignBytes {

--- a/bindgen/templates/RustBufferTemplate.go
+++ b/bindgen/templates/RustBufferTemplate.go
@@ -39,7 +39,7 @@ func CFromRustBuffer(b ExternalCRustBuffer) C.RustBuffer {
 	return C.RustBuffer {
 		capacity: C.uint64_t(b.Capacity()),
 		len: C.uint64_t(b.Len()),
-		data: (*C.uchar)(b.Data()),
+		data: C.uintptr_t(uintptr(b.Data())),
 	}
 }
 
@@ -48,7 +48,7 @@ func RustBufferFromExternal(b ExternalCRustBuffer) GoRustBuffer {
 		inner: C.RustBuffer {
 			capacity: C.uint64_t(b.Capacity()),
 			len: C.uint64_t(b.Len()),
-			data: (*C.uchar)(b.Data()),
+			data: C.uintptr_t(uintptr(b.Data())),
 		},
 	}
 }
@@ -62,11 +62,17 @@ func (cb GoRustBuffer) Len() uint64 {
 }
 
 func (cb GoRustBuffer) Data() unsafe.Pointer {
-	return unsafe.Pointer(cb.inner.data)
+	if cb.inner.capacity == 0 {
+		return nil
+	}
+	return unsafe.Pointer(uintptr(cb.inner.data))
 }
 
 func (cb GoRustBuffer) AsReader() *bytes.Reader {
-	b := unsafe.Slice((*byte)(cb.inner.data), C.uint64_t(cb.inner.len))
+	if cb.inner.capacity == 0 {
+		return bytes.NewReader(nil)
+	}
+	b := unsafe.Slice((*byte)(unsafe.Pointer(uintptr(cb.inner.data))), C.uint64_t(cb.inner.len))
 	return bytes.NewReader(b)
 }
 
@@ -78,9 +84,11 @@ func (cb GoRustBuffer) Free() {
 }
 
 func (cb GoRustBuffer) ToGoBytes() []byte {
-	return C.GoBytes(unsafe.Pointer(cb.inner.data), C.int(cb.inner.len))
+	if cb.inner.capacity == 0 {
+		return make([]byte, 0)
+	}
+	return C.GoBytes(unsafe.Pointer(uintptr(cb.inner.data)), C.int(cb.inner.len))
 }
-
 
 func stringToRustBuffer(str string) C.RustBuffer {
 	return bytesToRustBuffer([]byte(str))
@@ -96,7 +104,7 @@ func bytesToRustBuffer(b []byte) C.RustBuffer {
 		len: C.int(len(b)),
 		data: (*C.uchar)(unsafe.Pointer(&b[0])),
 	}
-	
+
 	return rustCall(func( status *C.RustCallStatus) C.RustBuffer {
 		return C.{{ ci.ffi_rustbuffer_from_bytes().name() }}(foreign, status)
 	})

--- a/binding_tests/issue_83_test.go
+++ b/binding_tests/issue_83_test.go
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package binding_tests
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/NordSecurity/uniffi-bindgen-go/binding_tests/generated/issue83"
+)
+
+type noopStringReceiver struct{}
+
+func (noopStringReceiver) Receive(string) {}
+
+const stackSweepDepth = 1024
+
+//go:noinline
+func invokeAtStackDepth(depth int) {
+	if depth <= 0 {
+		issue83.InvokeStringReceiver(noopStringReceiver{})
+		return
+	}
+	var pad [16]byte
+	pad[0] = byte(depth)
+	invokeAtStackDepth(depth - 1)
+	runtime.KeepAlive(&pad)
+}
+
+// Ensure dangling pointers do not cause panic when stack is scanned.
+// https://github.com/NordSecurity/uniffi-bindgen-go/issues/83
+func TestIssue83(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for depth := 0; depth < stackSweepDepth; depth++ {
+			runtime.GC()
+			invokeAtStackDepth(depth)
+		}
+	}()
+	<-done
+}

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -49,6 +49,7 @@ uniffi-go-fixture-destroy = { path = "destroy" }
 uniffi-go-fixture-errors = { path = "errors" }
 uniffi-go-fixture-issue43 = { path = "regressions/issue43" }
 uniffi-go-fixture-issue45 = { path = "regressions/issue45" }
+uniffi-go-fixture-issue83 = { path = "regressions/issue83" }
 uniffi-go-fixture-name-case = { path = "name-case" }
 uniffi-go-fixture-objects = { path = "objects" }
 uniffi-go-fixture-empty-string-and-bytes = { path = "empty_string_and_bytes"}

--- a/fixtures/regressions/issue83/Cargo.toml
+++ b/fixtures/regressions/issue83/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "uniffi-go-fixture-issue83"
+version = "1.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_go_issue83"
+
+[dependencies]
+uniffi.workspace = true
+uniffi_macros.workspace = true
+
+[build-dependencies]
+uniffi_build.workspace = true

--- a/fixtures/regressions/issue83/build.rs
+++ b/fixtures/regressions/issue83/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/issue83.udl").unwrap();
+}

--- a/fixtures/regressions/issue83/src/issue83.udl
+++ b/fixtures/regressions/issue83/src/issue83.udl
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+namespace issue83 {
+    void invoke_string_receiver(StringReceiver receiver);
+};
+
+[Trait, WithForeign]
+interface StringReceiver {
+    void receive(string value);
+};

--- a/fixtures/regressions/issue83/src/lib.rs
+++ b/fixtures/regressions/issue83/src/lib.rs
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::Arc;
+
+#[uniffi::trait_interface]
+pub trait StringReceiver: Send + Sync {
+    fn receive(&self, value: String);
+}
+
+/// Hand an empty `String` to a foreign-implemented receiver.
+///
+/// An empty `String` lowers into a `RustBuffer` whose `data` pointer
+/// points to non-null, dangling value (Rust's `NonNull::dangling()`).
+/// On the Go side that pointer lives on the cgo callback's stack frame
+/// and must not be treated as Go pointer. Otherwise, if the stack is scanned
+/// the runtime complains about invalid pointer.
+pub fn invoke_string_receiver(receiver: Arc<dyn StringReceiver>) {
+    receiver.receive(String::new());
+}
+
+include!(concat!(env!("OUT_DIR"), "/issue83.uniffi.rs"));

--- a/fixtures/src/lib.rs
+++ b/fixtures/src/lib.rs
@@ -38,6 +38,7 @@ mod uniffi_fixtures {
     uniffi_go_errors::uniffi_reexport_scaffolding!();
     uniffi_go_issue43::uniffi_reexport_scaffolding!();
     uniffi_go_issue45::uniffi_reexport_scaffolding!();
+    uniffi_go_issue83::uniffi_reexport_scaffolding!();
     uniffi_go_name_case::uniffi_reexport_scaffolding!();
     uniffi_go_objects::uniffi_reexport_scaffolding!();
     uniffi_go_empty_string_and_bytes::uniffi_reexport_scaffolding!();


### PR DESCRIPTION
Should resolve https://github.com/NordSecurity/uniffi-bindgen-go/issues/83. The issue is already well documented, so just a quick recap:

An empty `String`/`Vec` lowers to a `RustBuffer` whose `data` field is Rust's `NonNull::dangling()` sentinel. Because that field is typed as `*C.uchar` Go's GC treats it as a managed pointer. If a `copystack` runs while the value is on the stack, Go's runtime treats it as invalid pointer and crashes.

This PR changes `data` from `uint8_t*` to `uintptr_t`, so the GC no longer scans it as a pointer. I've also added a `capacity == 0` guard in `AsReader`/`ToGoBytes`/`Data` so the dangling sentinel is never turned back into a Go pointer.