### PR TITLE
Upgrade to uniffi 0.32.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.87
+      image: rust:1.91
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v0.8.0+v0.32.0
+- **BREAKING** Upgrade to `uniffi-rs` v0.32.0
+- **BREAKING** Bump MSRV to 1.91
+- Load config through UniFFI's new `GlobalConfig`, so `--config` takes a global config file
+  with `[defaults]`, `[crates.<name>]`, and `[crate-roots]` sections
+- Add `HashSet<T>` support, generated as Go's `map[T]struct{}`
+- Treat `Box<T>` as a plain `T`, matching the other binding generators
+
 ### v0.7.1+v0.31.0
 - Fix async error propagation for RustBuffer-backed Go returns
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,11 +73,11 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
- "askama_derive 0.14.0",
+ "askama_macros",
  "itoa",
  "percent-encoding",
  "serde",
@@ -103,12 +103,13 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
 dependencies = [
- "askama_parser 0.14.0",
+ "askama_parser 0.16.0",
  "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -116,6 +117,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "syn",
+]
+
+[[package]]
+name = "askama_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
+dependencies = [
+ "askama_derive 0.16.0",
 ]
 
 [[package]]
@@ -132,14 +142,15 @@ dependencies = [
 
 [[package]]
 name = "askama_parser"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
 dependencies = [
- "memchr",
+ "rustc-hash",
  "serde",
  "serde_derive",
- "winnow 0.7.15",
+ "unicode-ident",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -342,18 +353,19 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -580,6 +592,15 @@ name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
 ]
@@ -908,19 +929,19 @@ dependencies = [
 [[package]]
 name = "large-enum"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "large-error"
 version = "0.26.1"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
@@ -1209,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1365,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1375,32 +1396,32 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "unicode-ident"
@@ -1428,54 +1449,54 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
+checksum = "a782a48d72cfd7a2d65cfc7c691dbf5375c43104b3c195f7eccc716dcc3540c8"
 dependencies = [
  "anyhow",
  "camino",
  "cargo_metadata",
  "clap",
- "uniffi_bindgen 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_core 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+version = "0.32.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "uniffi_bindgen 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
- "uniffi_build 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
- "uniffi_core 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
- "uniffi_macros 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
- "uniffi_pipeline 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_bindgen 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
+ "uniffi_build 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
+ "uniffi_core 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
+ "uniffi_macros 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
+ "uniffi_pipeline 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-bindgen-go"
-version = "0.7.1+v0.31.0"
+version = "0.8.0+v0.32.0"
 dependencies = [
  "anyhow",
  "askama 0.13.1",
  "camino",
  "clap",
  "extend",
- "fs-err",
+ "fs-err 2.11.0",
  "heck",
  "paste",
  "serde",
  "serde_json",
  "textwrap",
  "toml",
- "uniffi_bindgen 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_udl 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1521,140 +1542,140 @@ dependencies = [
 [[package]]
 name = "uniffi-example-arithmetic"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-example-callbacks"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-example-custom-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
  "url",
 ]
 
 [[package]]
 name = "uniffi-example-futures"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "async-std",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-example-geometry"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-example-rondpoint"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-example-sprites"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-example-todolist"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "once_cell",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-example-traits"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-callbacks"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-coverall"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "once_cell",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-docstring"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-enum-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-error-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-ext-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-external-crate",
@@ -1666,38 +1687,38 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-ext-types-custom-types"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "bytes",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-ext-types-external-crate"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 
 [[package]]
 name = "uniffi-fixture-ext-types-lib-one"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "bytes",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-ext-types-proc-macro"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "bytes",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
  "uniffi-example-custom-types",
  "uniffi-fixture-ext-types-custom-types",
  "uniffi-fixture-ext-types-lib-one",
@@ -1707,10 +1728,10 @@ dependencies = [
 [[package]]
 name = "uniffi-fixture-ext-types-sub-lib"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
  "uniffi-fixture-ext-types-lib-one",
 ]
 
@@ -1723,63 +1744,63 @@ dependencies = [
  "once_cell",
  "thiserror 1.0.69",
  "tokio",
- "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-fixture-proc-macro"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "lazy_static",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-simple-fns"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-simple-iface"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "lazy_static",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-time"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "chrono",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-trait-methods"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "once_cell",
  "thiserror 2.0.18",
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi-fixture-type-limits"
 version = "0.22.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
- "uniffi 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
@@ -1788,18 +1809,18 @@ version = "1.0.0"
 dependencies = [
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-go-fixture-empty-string-and-bytes"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1807,28 +1828,28 @@ name = "uniffi-go-fixture-errors"
 version = "1.0.0"
 dependencies = [
  "thiserror 1.0.69",
- "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-go-fixture-issue43"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi-go-fixture-issue45",
- "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi-go-fixture-issue45"
 version = "1.0.0"
 dependencies = [
- "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1837,8 +1858,8 @@ version = "0.22.0"
 dependencies = [
  "glob",
  "thiserror 1.0.69",
- "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_bindgen 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_testing",
 ]
 
@@ -1849,22 +1870,22 @@ dependencies = [
  "crossbeam",
  "once_cell",
  "thiserror 1.0.69",
- "uniffi 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_build 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_build 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
+checksum = "533b0312c73e3b54eb78a4b257ceae390962dd4767995778309a74644643f9ac"
 dependencies = [
  "anyhow",
- "askama 0.14.0",
+ "askama 0.16.0",
  "camino",
  "cargo_metadata",
- "fs-err",
+ "fs-err 3.3.1",
  "glob",
  "goblin",
  "heck",
@@ -1874,23 +1895,23 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml",
- "uniffi_internal_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_meta 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uniffi_testing",
- "uniffi_udl 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_udl 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+version = "0.32.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
- "askama 0.14.0",
+ "askama 0.16.0",
  "camino",
  "cargo_metadata",
- "fs-err",
+ "fs-err 3.3.1",
  "glob",
  "goblin",
  "heck",
@@ -1900,38 +1921,38 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml",
- "uniffi_internal_macros 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
- "uniffi_meta 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
- "uniffi_pipeline 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
- "uniffi_udl 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_internal_macros 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
+ "uniffi_meta 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
+ "uniffi_pipeline 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
+ "uniffi_udl 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78fd9271a4c2e85bd2c266c5a9ede1fac676eb39fd77f636c27eaf67426fd5f"
+checksum = "763a19ad720fce8c9a98576e04c0ccc5d2d155aa6b953c864587073292c7ccfc"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_bindgen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+version = "0.32.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_bindgen 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
+checksum = "8e32e261c5b0dfaba6488f536e71957dddd6b1a498ac7eb791bee56b60a086be"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1942,8 +1963,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+version = "0.32.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1953,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
+checksum = "84ae78069a5e6772ef694fd5bdb628532c88d2c2f0e7142bf6a384636eadb1af"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1966,8 +1987,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+version = "0.32.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1978,119 +1999,119 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
+checksum = "330be6770532e86320df31f54c70bb0be67588594e8e77fa56e9083a3fed5d0d"
 dependencies = [
  "camino",
- "fs-err",
+ "fs-err 3.3.1",
  "once_cell",
  "proc-macro2",
  "quote",
  "serde",
  "syn",
  "toml",
- "uniffi_meta 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+version = "0.32.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "camino",
- "fs-err",
+ "fs-err 3.3.1",
  "once_cell",
  "proc-macro2",
  "quote",
  "serde",
  "syn",
  "toml",
- "uniffi_meta 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_meta 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
+checksum = "78de021f5547e56ab16c665a49d67d4fd3d31e77422f7739a2e9359d328cd9e7"
 dependencies = [
  "anyhow",
  "siphasher",
- "uniffi_internal_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uniffi_pipeline 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_pipeline 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+version = "0.32.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "siphasher",
- "uniffi_internal_macros 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
- "uniffi_pipeline 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_internal_macros 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
+ "uniffi_pipeline 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
+checksum = "3f8201bb1907ed8a42d80e11cbc25c8a033e7a31c3cff1d911f56eedb81d4948"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap",
  "tempfile",
- "uniffi_internal_macros 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_internal_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+version = "0.32.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap",
  "tempfile",
- "uniffi_internal_macros 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_internal_macros 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
 name = "uniffi_testing"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4802bed208a296657eef3451a961a6502e1d7aa8930b4b0cd952ed4f81a3957e"
+checksum = "fec91e7b3d258554335da3d4ecf3d055f7bb4a34aa52b89d28ad2380e10579a0"
 dependencies = [
  "anyhow",
  "camino",
  "cargo_metadata",
- "fs-err",
+ "fs-err 3.3.1",
  "once_cell",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
+checksum = "a6e57996bc58009cc29bf04845d627ae313c2547b87171c1c349d6c51a1656c0"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uniffi_meta 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle2 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+version = "0.32.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta 0.31.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
- "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0)",
+ "uniffi_meta 0.32.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
+ "weedle2 5.0.0 (git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0)",
 ]
 
 [[package]]
@@ -2256,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.31.0#309762f55db3f0548194a9ceba3027fa64b18a93"
+source = "git+https://github.com/mozilla/uniffi-rs.git?tag=v0.32.0#5c7b73906358e1a7acdc1bdc7bf5cd86fb27e44c"
 dependencies = [
  "nom",
 ]
@@ -2290,6 +2311,9 @@ name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-rust-version = "1.87"
+rust-version = "1.91"
 members = [
     "bindgen",
     "fixtures",
@@ -12,10 +12,10 @@ members = [
 ]
 
 [workspace.dependencies]
-uniffi = "0.31.0"
-uniffi_testing = "0.31.0"
-uniffi_macros = "0.31.0"
-uniffi_build = { version = "0.31.0", features=["builtin-bindgen"] }
-uniffi_bindgen = "0.31.0"
-uniffi_meta = "0.31.0"
-uniffi_udl = "0.31.0"
+uniffi = "0.32.0"
+uniffi_testing = "0.32.0"
+uniffi_macros = "0.32.0"
+uniffi_build = { version = "0.32.0", features=["builtin-bindgen"] }
+uniffi_bindgen = "0.32.0"
+uniffi_meta = "0.32.0"
+uniffi_udl = "0.32.0"

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 Generate [UniFFI](https://github.com/mozilla/uniffi-rs) bindings for Go. `uniffi-bindgen-go` lives
 as a separate project from `uniffi-go`, as per
 [uniffi-rs #1355](https://github.com/mozilla/uniffi-rs/issues/1355). Currently, `uniffi-bindgen-go`
-uses `uniffi-rs` version `0.31.0`.
+uses `uniffi-rs` version `0.32.0`.
 
 # How to install
 
-Minimum Rust version required to install `uniffi-bindgen-go` is `1.87`.
+Minimum Rust version required to install `uniffi-bindgen-go` is `1.91`.
 Newer Rust versions should also work fine.
 
 ```
-cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.7.1+v0.31.0
+cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.8.0+v0.32.0
 ```
 
 # How to generate bindings
@@ -67,6 +67,7 @@ The table shows the `uniffi-rs` version targeted by each published `uniffi-bindg
 
 | uniffi-bindgen-go version                | uniffi-rs version                                |
 |------------------------------------------|--------------------------------------------------|
+| v0.8.0                                   | v0.32.0                                          |
 | v0.7.0                                   | v0.31.0                                          |
 | v0.6.0                                   | v0.30.0                                          |
 | v0.5.0                                   | v0.29.5                                          |

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-bindgen-go"
-version = "0.7.1+v0.31.0"
+version = "0.8.0+v0.32.0"
 edition = "2021"
 
 [lib]
@@ -18,7 +18,10 @@ clap = { version = "4", features = ["cargo", "std", "derive"] }
 extend = "1.1"
 heck = "0.5"
 serde = "1"
-toml = "0.9"
+# Must match uniffi_bindgen's own range exactly. It declares ">=0.9, <2", which spans
+# two semver-incompatible majors, so a narrower range here lets cargo resolve a second
+# toml for us and `toml::Value` stops being one type.
+toml = ">=0.9, <2"
 camino = "1.0.8"
 fs-err = "2.7.0"
 paste = "1.0"

--- a/bindgen/src/gen_go/compounds.rs
+++ b/bindgen/src/gen_go/compounds.rs
@@ -56,6 +56,11 @@ macro_rules! impl_code_type_for_compound {
 
 impl_code_type_for_compound!(OptionalCodeType, "*{}", "Optional{}");
 impl_code_type_for_compound!(SequenceCodeType, "[]{}", "Sequence{}");
+// Go has no set type, so a `HashSet<T>` becomes the idiomatic `map[T]struct{}`. Rust's
+// `Hash + Eq` is wider than Go's comparable types, so an inner type rendering as a slice
+// or map produces Go that does not compile. `MapCodeType` keys have the same bound and
+// the same gap; the two stay consistent rather than one being stricter.
+impl_code_type_for_compound!(SetCodeType, "map[{}]struct{{}}", "Set{}");
 
 #[derive(Debug)]
 pub struct MapCodeType<'a> {

--- a/bindgen/src/gen_go/mod.rs
+++ b/bindgen/src/gen_go/mod.rs
@@ -427,6 +427,9 @@ impl GoCodeOracle {
             Type::Sequence { inner_type } => {
                 Box::new(compounds::SequenceCodeType::new(*inner_type, ci))
             }
+            Type::Set { inner_type } => Box::new(compounds::SetCodeType::new(*inner_type, ci)),
+            // `Box<T>` only exists for scaffolding; it crosses the FFI as a plain `T`.
+            Type::Box { inner_type } => self.create_code_type(*inner_type, ci),
             Type::Timestamp => Box::new(miscellany::TimestampCodeType),
             Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),
 

--- a/bindgen/src/lib.rs
+++ b/bindgen/src/lib.rs
@@ -11,7 +11,7 @@ use fs_err::{self as fs};
 use gen_go::generate_go_bindings;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
-use uniffi_bindgen::{BindgenLoader, BindgenPaths, Component, GenerationSettings};
+use uniffi_bindgen::{BindgenLoader, BindgenPaths, Component, GenerationSettings, GlobalConfig};
 
 #[derive(Parser)]
 #[clap(name = "uniffi-bindgen")]
@@ -26,9 +26,9 @@ struct Cli {
     #[clap(long, short)]
     no_format: bool,
 
-    /// Path to optional uniffi config file. This config will be merged on top of default
-    /// `uniffi.toml` config in crate root. The merge recursively upserts TOML keys into
-    /// the default config.
+    /// Path to a global config file. Supports `[defaults]`, `[crates.<name>]`, and
+    /// `[crate-roots]` sections. `[defaults]` is merged with each crate's `uniffi.toml`,
+    /// then `[crates.<name>]` overrides win.
     #[clap(long, short)]
     config: Option<Utf8PathBuf>,
 
@@ -145,12 +145,19 @@ pub fn main() -> anyhow::Result<()> {
     } = Cli::parse();
 
     let mut bindgen_paths = BindgenPaths::default();
-    if let Some(config_path) = &config {
-        bindgen_paths.add_config_override_layer(config_path.clone());
-    }
+    let global_config = match &config {
+        Some(config_path) => {
+            let (global_config, crate_roots_layer) = GlobalConfig::from_file(config_path)?;
+            if let Some(layer) = crate_roots_layer {
+                bindgen_paths.add_layer(layer);
+            }
+            global_config
+        }
+        None => GlobalConfig::default(),
+    };
     bindgen_paths.add_cargo_metadata_layer(false)?;
 
-    let loader = BindgenLoader::new(bindgen_paths);
+    let loader = BindgenLoader::new(bindgen_paths, global_config);
     let binding_gen = BindingGeneratorGo;
 
     let metadata = loader.load_metadata(&source)?;

--- a/bindgen/templates/SetTemplate.go
+++ b/bindgen/templates/SetTemplate.go
@@ -1,0 +1,51 @@
+{#/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */#}
+
+{{- self.add_import("math") }}
+
+{%- let inner_type_name = inner_type|type_name(ci) %}
+
+type {{ ffi_converter_name }} struct {}
+
+var {{ ffi_converter_instance }} = {{ ffi_converter_name }}{}
+
+func (c {{ ffi_converter_name }}) Lift(rb RustBufferI) {{ type_name }} {
+	return LiftFromRustBuffer[{{ type_name }}](c, rb)
+}
+
+func (_ {{ ffi_converter_name }}) Read(reader io.Reader) {{ type_name }} {
+	length := readInt32(reader)
+	result := make({{ type_name }}, length)
+	for i := int32(0); i < length; i++ {
+		result[{{ inner_type|read_fn(ci) }}(reader)] = struct{}{}
+	}
+	return result
+}
+
+func (c {{ ffi_converter_name }}) Lower(value {{ type_name }}) C.RustBuffer {
+	return LowerIntoRustBuffer[{{ type_name }}](c, value)
+}
+
+func (c {{ ffi_converter_name }}) LowerExternal(value {{ type_name }}) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[{{ type_name }}](c, value))
+}
+
+func (_ {{ ffi_converter_name }}) Write(writer io.Writer, setValue {{ type_name }}) {
+	if len(setValue) > math.MaxInt32 {
+		panic("{{ type_name }} is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(setValue)))
+	for value := range setValue {
+		{{ inner_type|write_fn(ci) }}(writer, value)
+	}
+}
+
+type {{ ffi_destroyer_name }} struct {}
+
+func (_ {{ ffi_destroyer_name }}) Destroy(setValue {{ type_name }}) {
+	for value := range setValue {
+		{{ inner_type|destroy_fn(ci) }}(value)
+	}
+}

--- a/bindgen/templates/Types.go
+++ b/bindgen/templates/Types.go
@@ -78,6 +78,9 @@
 {%- when Type::Sequence { inner_type }  %}
 {% include "SequenceTemplate.go" %}
 
+{%- when Type::Set { inner_type } %}
+{% include "SetTemplate.go" %}
+
 {%- when Type::Map { key_type, value_type } %}
 {% include "MapTemplate.go" %}
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,9 +1,21 @@
 # Configuration options
 
-It's possible to configure some settings by passing `--config` argument to the generator. All
-configuration keys are defined in `bindings.go` section.
+Settings come from each crate's own `uniffi.toml`, under a `bindings.go` section. All
+configuration keys below are defined there.
+
+A crate's `uniffi.toml` is picked up automatically. To set values across crates, pass a
+global config file with `--config`, which nests the same keys under `[defaults]` (applied
+under every crate's own config) or `[crates.<name>]` (applied over it).
 ```bash
-uniffi-bindgen-go path/to/definitions.udl --config path/to/uniffi.toml
+uniffi-bindgen-go path/to/definitions.udl --config path/to/global.toml
+```
+```toml
+# global.toml
+[defaults.bindings.go]
+go_mod = "github.com/example/generated"
+
+[crates.my_crate.bindings.go]
+package_name = "mycrate"
 ```
 
 - `package_name` - override the go package name.

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -10,39 +10,39 @@ crate-type = ["cdylib", "staticlib", "lib"]
 
 [dependencies]
 # Examples
-uniffi-example-arithmetic = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-example-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-example-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-example-sprites = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-example-todolist = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-example-traits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-example-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-example-arithmetic = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-example-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-example-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-example-geometry = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-example-rondpoint = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-example-sprites = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-example-todolist = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-example-traits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-example-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
 
 # Fixtures
 # NOTE: taken from upstream, due to collision between new_megaphone and Megaphone interface constructor names
-# uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+# uniffi-fixture-futures = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
 uniffi-fixture-futures = { path = "./futures" }
 
 
-uniffi-fixture-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-docstring = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-enum-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-error-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-ext-types-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-ext-types-lib-one = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-ext-types-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-large-enum = { package = "large-enum", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-large-error = { package = "large-error", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-simple-fns = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-simple-iface = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-trait-methods = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
-uniffi-fixture-type-limits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.31.0"}
+uniffi-fixture-callbacks = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-coverall = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-docstring = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-enum-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-error-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-ext-types-custom-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-ext-types = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-ext-types-lib-one = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-ext-types-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-large-enum = { package = "large-enum", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-large-error = { package = "large-error", git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-proc-macro = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-simple-fns = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-simple-iface = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-time = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-trait-methods = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
+uniffi-fixture-type-limits = { git = "https://github.com/mozilla/uniffi-rs.git", tag = "v0.32.0"}
 
 # Go specific
 uniffi-go-fixture-destroy = { path = "destroy" }

--- a/fixtures/uniffi.toml
+++ b/fixtures/uniffi.toml
@@ -1,4 +1,7 @@
-[bindings.go.custom_types.Url]
+# A global config file, as `--config` expects since uniffi 0.32. `[defaults]` is
+# merged underneath each crate's own `uniffi.toml`.
+
+[defaults.bindings.go.custom_types.Url]
 imports = ["net/url"]
 type_name = "url.URL"
 into_custom = """u, err := url.Parse({})
@@ -10,5 +13,5 @@ into_custom = """u, err := url.Parse({})
 from_custom = "{}.String()"
 
 
-[bindings.go]
+[defaults.bindings.go]
 go_mod = "github.com/NordSecurity/uniffi-bindgen-go/binding_tests/generated"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.87"
+channel = "1.91"


### PR DESCRIPTION
(AI generated, human reviewed)

The metadata encoding changed in uniffi 0.32 even though the contract version did not, so v0.7.1+v0.31.0 cannot read a 0.32-built cdylib at all: it fails with "Invalid string data" while extracting the first constructor's metadata.

Three things needed porting:

- Config now loads through `GlobalConfig` (uniffi #2866). `--config` takes a global config file with `[defaults]`, `[crates.<name>]`, and `[crate-roots]` sections rather than a flat `uniffi.toml`-shaped override, and `BindgenLoader::new` takes the parsed config. `fixtures/uniffi.toml` moves to the new shape.
- `Type::Set` is new. Go has no set type, so a `HashSet<T>` renders as the idiomatic `map[T]struct{}`; the wire format is identical to a sequence.
- `Type::Box` is new. It exists only for scaffolding, so it renders as its inner type.

The uniffi example and fixture crates move to the v0.32.0 tag so the fixture library carries one metadata version rather than a 0.31/0.32 mix.

MSRV goes to 1.91, which uniffi 0.32 requires.